### PR TITLE
Add `brew cask` content to homepage.

### DIFF
--- a/_data/locales/ar.yml
+++ b/_data/locales/ar.yml
@@ -11,6 +11,8 @@ ar:
     formula: "وصفات \"formulae\" الـHomebrew عبارة عن سكربتات Ruby بسيطة:"
     editor: opens in $EDITOR!
     complement: Homebrew مكمل للـMac، ثبّت الـgems بواسطة <code>gem</code> وثبّت متطلباتها بواسطة <code>brew</code>.
+    caskinstall: '"To install, drag this icon..." no more. <code>brew cask</code> installs macOS apps, fonts and plugins and other non-open source software.'
+    caskcreate: Making a cask is as simple as creating a formula.
     install:
       install: ثبّت Homebrew
       paste: الصق ذلك في الطرفية

--- a/_data/locales/az.yml
+++ b/_data/locales/az.yml
@@ -11,6 +11,8 @@ az:
     formula: "Homebrew formulaları sadə Ruby proqramlarıdır:"
     editor: opens in $EDITOR!
     complement: Homebrew macOS-i tamamlayır. Gemlərinizi <code>gem</code> ilə, onların asılılıqlarını isə <code>brew</code> ilə yükləyin.
+    caskinstall: '"To install, drag this icon..." no more. <code>brew cask</code> installs macOS apps, fonts and plugins and other non-open source software.'
+    caskcreate: Making a cask is as simple as creating a formula.
     install:
       install: Homebrew-i yükləyin
       paste: Bunu Terminal-a əlavə edin.

--- a/_data/locales/be.yml
+++ b/_data/locales/be.yml
@@ -11,6 +11,8 @@ be:
     formula: "Формулы Homebrew — гэта простыя скрыпты на Ruby:"
     editor: адкрыецца ў $EDITOR!
     complement: Homebrew дапаўняе macOS. Усталёўвайце гемы камандай <code>gem</code>, а іх залежнасці — <code>brew</code>.
+    caskinstall: '"To install, drag this icon..." no more. <code>brew cask</code> installs macOS apps, fonts and plugins and other non-open source software.'
+    caskcreate: Making a cask is as simple as creating a formula.
     install:
       install: Усталяванне Homebrew
       paste: Скапіруйце і ўстаўце гэта ў тэрмінал.

--- a/_data/locales/bg.yml
+++ b/_data/locales/bg.yml
@@ -11,6 +11,8 @@ bg:
     formula: "Homebrew формулите са прости Ruby скриптове:"
     editor: opens in $EDITOR!
     complement: Homebrew допълва macOS. Инсталирайте gem пакети, използвайки <code>gem</code>, а техните зависимости чрез <code>brew</code>.
+    caskinstall: '"To install, drag this icon..." no more. <code>brew cask</code> installs macOS apps, fonts and plugins and other non-open source software.'
+    caskcreate: Making a cask is as simple as creating a formula.
     install:
       install: Инсталиране на Homebrew
       paste: Поставете това в терминал.

--- a/_data/locales/ca.yml
+++ b/_data/locales/ca.yml
@@ -11,6 +11,8 @@ ca:
     formula: "Les fórmules de Homebrew són senzills <i>scripts</i> Ruby:"
     editor: opens in $EDITOR!
     complement: Homebrew complementa macOS. Instal·la les teves <i>gems</i> amb <code>gem</code>, i les seves dependències amb <code>brew</code>.
+    caskinstall: '"To install, drag this icon..." no more. <code>brew cask</code> installs macOS apps, fonts and plugins and other non-open source software.'
+    caskcreate: Making a cask is as simple as creating a formula.
     install:
       install: Instal·la Homebrew
       paste: Enganxa el codi a una finestra de Terminal.

--- a/_data/locales/cs.yml
+++ b/_data/locales/cs.yml
@@ -11,6 +11,8 @@ cs:
     formula: "Formule Homebrew jsou jednoduché Ruby scripty:"
     editor: otevře se v $EDITOR!
     complement: Homebrew doplňuje macOS. Instalujte vaše gemy příkazem <code>gem</code> a jejich závislosti příkazem <code>brew</code>.
+    caskinstall: '"To install, drag this icon..." no more. <code>brew cask</code> installs macOS apps, fonts and plugins and other non-open source software.'
+    caskcreate: Making a cask is as simple as creating a formula.
     install:
       install: Instalace Homebrew
       paste: Tohle vložte do okna Terminálu.

--- a/_data/locales/da.yml
+++ b/_data/locales/da.yml
@@ -13,6 +13,8 @@ da:
     formula: "Homebrew formularer er simple Rubyscripts:"
     editor: åbner i $EDITOR!
     complement: Homebrew komplimenterer macOS. Installer dine gems med <code>gem</code> og pakkerne de er afhængige af med <code>brew</code>.
+    caskinstall: '"To install, drag this icon..." no more. <code>brew cask</code> installs macOS apps, fonts and plugins and other non-open source software.'
+    caskcreate: Making a cask is as simple as creating a formula.
     install:
       install: Installer Homebrew
       paste: Kopier og indsæt i din Terminal

--- a/_data/locales/de.yml
+++ b/_data/locales/de.yml
@@ -11,6 +11,8 @@ de:
     formula: "Homebrew-Formeln sind einfache Ruby-Skripte:"
     editor: wird in $EDITOR geöffnet!
     complement: Homebrew ergänzt macOS. Installiere deine Gems mit <code>gem</code> und ihre Abhängigkeiten mit <code>brew</code>.
+    caskinstall: '"To install, drag this icon..." no more. <code>brew cask</code> installs macOS apps, fonts and plugins and other non-open source software.'
+    caskcreate: Making a cask is as simple as creating a formula.
     install:
       install: Installiere Homebrew
       paste: Füge das im Terminal ein.

--- a/_data/locales/en.yml
+++ b/_data/locales/en.yml
@@ -11,6 +11,10 @@ en:
     formula: "Homebrew formulae are simple Ruby scripts:"
     editor: opens in $EDITOR!
     complement: Homebrew complements macOS. Install your gems with <code>gem</code>, and their dependencies with <code>brew</code>.
+    caskinstall: '"To install, drag this icon..." no more. <code>brew cask</code> installs macOS apps, fonts and plugins and other non-open source software.'
+    caskcreate: Making a cask is as simple as creating a formula.
+    caskinstall: '"To install, drag this icon..." no more. <code>brew cask</code> installs macOS apps, fonts and plugins and other non-open source software.'
+    caskcreate: Making a cask is as simple as creating a formula.
     install:
       install: Install Homebrew
       paste: Paste that at a Terminal prompt.

--- a/_data/locales/es.yml
+++ b/_data/locales/es.yml
@@ -11,6 +11,8 @@ es:
     formula: "Las fórmulas de Homebrew son simples <i>scripts</i> en Ruby:"
     editor: opens in $EDITOR!
     complement: Homebrew complementa macOS. Instala tus <i>gems</i> con <code>gem</code> y sus dependencias con <code>brew</code>.
+    caskinstall: '"To install, drag this icon..." no more. <code>brew cask</code> installs macOS apps, fonts and plugins and other non-open source software.'
+    caskcreate: Making a cask is as simple as creating a formula.
     install:
       install: Instala Homebrew
       paste: Pega este código en una ventana del Terminal.

--- a/_data/locales/fa.yml
+++ b/_data/locales/fa.yml
@@ -11,6 +11,8 @@ fa:
     formula: "دستورات Homebrew اسکریپت‌های ساده Ruby هستند:"
     editor: بازنمودن در $EDITOR!
     complement: Homebrew مکمل macOS است. gemها را با دستور <code>gem</code> و وابستگی‌های (dependencies) آن را با <code>brew</code> نصب کنید.
+    caskinstall: '"To install, drag this icon..." no more. <code>brew cask</code> installs macOS apps, fonts and plugins and other non-open source software.'
+    caskcreate: Making a cask is as simple as creating a formula.
     install:
       install: نصب Homebrew
       paste: کد بالا را در خط فرمان ترمینال جایگذاری کنید.

--- a/_data/locales/fi.yml
+++ b/_data/locales/fi.yml
@@ -11,6 +11,8 @@ fi:
     formula: "Homebrew'n kaavat ovat yksinkertaisia Ruby-skriptejä:"
     editor: avautuu editorissa $EDITOR!
     complement: Homebrew täydentää macOS:ää. Asenna gemit <code>gem</code>illä ja niiden riippuvuudet <code>brew</code>'llä.
+    caskinstall: '"To install, drag this icon..." no more. <code>brew cask</code> installs macOS apps, fonts and plugins and other non-open source software.'
+    caskcreate: Making a cask is as simple as creating a formula.
     install:
       install: Asenna Homebrew
       paste: Liitä tämä komentokehotteeseen.

--- a/_data/locales/fr.yml
+++ b/_data/locales/fr.yml
@@ -11,6 +11,8 @@ fr:
     formula: "Les formules Homebrew sont de simples scripts Ruby&nbsp;:"
     editor: ouvre avec $EDITOR !
     complement: Homebrew est un complément pour macOS. Installez vos gems avec <code>gem</code>, et leurs dépendances avec <code>brew</code>.
+    caskinstall: '"To install, drag this icon..." no more. <code>brew cask</code> installs macOS apps, fonts and plugins and other non-open source software.'
+    caskcreate: Making a cask is as simple as creating a formula.
     install:
       install: Installer Homebrew
       paste: Copiez et collez dans une fenêtre du Terminal.

--- a/_data/locales/gl.yml
+++ b/_data/locales/gl.yml
@@ -11,6 +11,8 @@ gl:
     formula: "As fórmulas de Homebrew son simples <i>scripts</i> de Ruby"
     editor: ábrese co $EDITOR!
     complement: Homebrew complementa a macOS. Instala as túas <i>gems</i> con <code>gem</code>, e as súas dependencias con <code>brew</code>.
+    caskinstall: '"To install, drag this icon..." no more. <code>brew cask</code> installs macOS apps, fonts and plugins and other non-open source software.'
+    caskcreate: Making a cask is as simple as creating a formula.
     install:
       install: Instala Homebrew
       paste: Pega este código nunha Terminal.

--- a/_data/locales/he.yml
+++ b/_data/locales/he.yml
@@ -11,6 +11,8 @@ he:
     formula: "ב-Homebrew, ״נוסחאות״ ההתקנה הן סקריפטים פשוטים ב-Ruby:"
     editor: opens in $EDITOR!
     complement: Homebrew משלים את macOS. התקינו את ה-gems שלכם עם <code>gem</code>, ואת התלויות שלהם עם <code>brew</code>.
+    caskinstall: '"To install, drag this icon..." no more. <code>brew cask</code> installs macOS apps, fonts and plugins and other non-open source software.'
+    caskcreate: Making a cask is as simple as creating a formula.
     install:
       install: התקנת Homebrew
       paste: הדביקו את הנ״ל ב-Terminal.

--- a/_data/locales/it.yml
+++ b/_data/locales/it.yml
@@ -11,6 +11,8 @@ it:
     formula: "Le formule di Homebrew sono semplici script in Ruby:"
     editor: si apre in $EDITOR!
     complement: Homebrew completa macOS. Installa le tue gemme con <code>gem</code> e quindi le loro dipendenze con <code>brew</code>.
+    caskinstall: '"To install, drag this icon..." no more. <code>brew cask</code> installs macOS apps, fonts and plugins and other non-open source software.'
+    caskcreate: Making a cask is as simple as creating a formula.
     install:
       install: Installa Homebrew
       paste: Incolla questa riga su una finestra del Terminale.

--- a/_data/locales/ja.yml
+++ b/_data/locales/ja.yml
@@ -11,6 +11,8 @@ ja:
     formula: "Homebrew の formula はシンプルな Ruby スクリプトです:"
     editor: opens in $EDITOR!
     complement: Homebrew は macOS の機能を補完します。<code>gem</code> コマンドで gem を、そして <code>brew</code> コマンドでそれらの依存関係をインストールします。
+    caskinstall: '"To install, drag this icon..." no more. <code>brew cask</code> installs macOS apps, fonts and plugins and other non-open source software.'
+    caskcreate: Making a cask is as simple as creating a formula.
     install:
       install: インストール
       paste: このスクリプトをターミナルに貼り付け実行して下さい。

--- a/_data/locales/ko.yml
+++ b/_data/locales/ko.yml
@@ -11,6 +11,8 @@ ko:
     formula: "Homebrew formula는 간단한 Ruby 스크립트입니다:"
     editor: opens in $EDITOR!
     complement: Homebrew는 macOS 개발 환경을 개선합니다. <code>gem</code> 명령으로 gem을, <code>brew</code> 명령으로 gem의 의존성 모듈을 설치하세요.
+    caskinstall: '"To install, drag this icon..." no more. <code>brew cask</code> installs macOS apps, fonts and plugins and other non-open source software.'
+    caskcreate: Making a cask is as simple as creating a formula.
     install:
       install: Homebrew 설치하기
       paste: 터미널에 붙여넣기 하세요.

--- a/_data/locales/nl.yml
+++ b/_data/locales/nl.yml
@@ -11,6 +11,8 @@ nl:
     formula: "Homebrew-formules zijn simpele Ruby-scripts:"
     editor: opent in $EDITOR!
     complement: Homebrew vult macOS aan. Installeer je gems met <code>gem</code> en hun afhankelijkheden met <code>brew</code>.
+    caskinstall: '"To install, drag this icon..." no more. <code>brew cask</code> installs macOS apps, fonts and plugins and other non-open source software.'
+    caskcreate: Making a cask is as simple as creating a formula.
     install:
       install: Installeer Homebrew
       paste: Plak het bovenstaande in Terminal.

--- a/_data/locales/no.yml
+++ b/_data/locales/no.yml
@@ -11,6 +11,8 @@
     formula: 'Homebrew-formler er simple Ruby-script:'
     editor: opens in $EDITOR!
     complement: Homebrew utfyller macOS. Installer gems med <code>gem</code>, og pakkene de er avhengige av med <code>brew</code>.
+    caskinstall: '"To install, drag this icon..." no more. <code>brew cask</code> installs macOS apps, fonts and plugins and other non-open source software.'
+    caskcreate: Making a cask is as simple as creating a formula.
     install:
       install: Installer Homebrew
       paste: Lim dette inn i din Terminal.

--- a/_data/locales/pl.yml
+++ b/_data/locales/pl.yml
@@ -11,6 +11,8 @@ pl:
     formula: "Formuły Homebrewa to proste skrypty napisane w Ruby:"
     editor: opens in $EDITOR!
     complement: Homebrew jest uzupełnieniem systemu macOS. Instaluj Gemy używając polecenia <code>gem</code>, a ich zależności za pomocą komendy <code>brew</code>.
+    caskinstall: '"To install, drag this icon..." no more. <code>brew cask</code> installs macOS apps, fonts and plugins and other non-open source software.'
+    caskcreate: Making a cask is as simple as creating a formula.
     install:
       install: Zainstaluj Homebrewa
       paste: Wklej polecenie w swoim Terminalu.

--- a/_data/locales/pt-br.yml
+++ b/_data/locales/pt-br.yml
@@ -11,6 +11,8 @@ pt-br:
     formula: Homebrew formulas são simples scripts em Ruby.
     editor: opens in $EDITOR!
     complement: O Homebrew complementa o macOS. Instale suas gems com <code>gem</code>, e suas dependências com <code>brew</code>.
+    caskinstall: '"To install, drag this icon..." no more. <code>brew cask</code> installs macOS apps, fonts and plugins and other non-open source software.'
+    caskcreate: Making a cask is as simple as creating a formula.
     install:
       install: Instale o Homebrew
       paste: Copie esse código para um prompt do seu Terminal.

--- a/_data/locales/ro.yml
+++ b/_data/locales/ro.yml
@@ -11,6 +11,8 @@ ro:
     formula: "Formulele Homebrew sunt doar script-uri în Ruby."
     editor: Se deschide în $EDITOR!
     complement: Homebrew întregește macOS. Instalează gem-urile cu <code>gem</code> și dependențele sale cu <code>brew</code>.
+    caskinstall: '"To install, drag this icon..." no more. <code>brew cask</code> installs macOS apps, fonts and plugins and other non-open source software.'
+    caskcreate: Making a cask is as simple as creating a formula.
     install:
       install: Instalează Homebrew
       paste: Copiază această comandă în terminal.

--- a/_data/locales/ru.yml
+++ b/_data/locales/ru.yml
@@ -11,6 +11,8 @@ ru:
     formula: "Спецификация пакета это просто скрипт на Ruby:"
     editor: открывается в $EDITOR!
     complement: Homebrew дополняет macOS. Устанавливайте гемы, используя <code>gem</code>, а их зависимости через <code>brew</code>.
+    caskinstall: '"To install, drag this icon..." no more. <code>brew cask</code> installs macOS apps, fonts and plugins and other non-open source software.'
+    caskcreate: Making a cask is as simple as creating a formula.
     install:
       install: Установка Homebrew
       paste: Вставьте эту строку в терминал.

--- a/_data/locales/sr.yml
+++ b/_data/locales/sr.yml
@@ -11,6 +11,8 @@ sr:
     formula: "Homebrew формуле су само Ruby скрипте:"
     editor: отвара се у $EDITOR-у!
     complement: Homebrew допуњава macOS. Инсталирајте gem-ове са <code>gem</code>, и њихове депенденције са <code>brew</code> командом.
+    caskinstall: '"To install, drag this icon..." no more. <code>brew cask</code> installs macOS apps, fonts and plugins and other non-open source software.'
+    caskcreate: Making a cask is as simple as creating a formula.
     install:
       install: Инсталирај Homebrew
       paste: Налепите ово у прозор Терминала.

--- a/_data/locales/sv.yml
+++ b/_data/locales/sv.yml
@@ -11,6 +11,8 @@ sv:
     formula: "Homebrews formler är enkla Rubyskript:"
     editor: öppnas i $EDITOR!
     complement: Homebrew kompletterar macOS. Installera gems med <code>gem</code> och sedan paketens beroenden med <code>brew</code>.
+    caskinstall: '"To install, drag this icon..." no more. <code>brew cask</code> installs macOS apps, fonts and plugins and other non-open source software.'
+    caskcreate: Making a cask is as simple as creating a formula.
     install:
       install: Installera Homebrew
       paste: Klistra in det här i Terminal.app.

--- a/_data/locales/th.yml
+++ b/_data/locales/th.yml
@@ -11,6 +11,8 @@ th:
     formula: "Homebrew formula เป็นแค่สคริปภาษา Ruby ง่ายๆ:"
     editor: opens in $EDITOR!
     complement: Homebrew เติมเต็มให้กับ macOS. ติดตั้ง gem ทั้งหลายด้วย <code>gem</code> ส่วน dependency ต่าง ๆ ติดตั้งด้วย <code>brew</code>
+    caskinstall: '"To install, drag this icon..." no more. <code>brew cask</code> installs macOS apps, fonts and plugins and other non-open source software.'
+    caskcreate: Making a cask is as simple as creating a formula.
     install:
       install: วิธีการติดตั้ง Homebrew
       paste: คัดลอกคำสั่งด้านบนไปรันใน Terminal

--- a/_data/locales/tr.yml
+++ b/_data/locales/tr.yml
@@ -11,6 +11,8 @@ tr:
     formula: "Homebrew formülleri yalın Ruby betikleridir:"
     editor: $EDITOR de açar!
     complement: Homebrew macOS'i tamamlar. Gemlerinizi <code>gem</code> ile, ve gereksinimleri <code>brew</code> ile yükleyin.
+    caskinstall: '"To install, drag this icon..." no more. <code>brew cask</code> installs macOS apps, fonts and plugins and other non-open source software.'
+    caskcreate: Making a cask is as simple as creating a formula.
     install:
       install: Homebrew'i yükleyin
       paste: Üstteki kod parçacığını bir Terminal penceresine yapıştırın.

--- a/_data/locales/uk.yml
+++ b/_data/locales/uk.yml
@@ -11,6 +11,8 @@ uk:
     formula: "Формули Homebrew — це прості скрипти на Ruby:"
     editor: відкриється в $EDITOR!
     complement: Homebrew доповнює macOS. Встановлюйте геми з <code>gem</code>, а їх залежності з <code>brew</code>.
+    caskinstall: '"To install, drag this icon..." no more. <code>brew cask</code> installs macOS apps, fonts and plugins and other non-open source software.'
+    caskcreate: Making a cask is as simple as creating a formula.
     install:
       install: Встановлення Homebrew
       paste: Запустіть цей код в Terminal.

--- a/_data/locales/vi.yml
+++ b/_data/locales/vi.yml
@@ -11,6 +11,8 @@ vi:
     formula: "Công thức Homebrew đơn giản là Ruby script:"
     editor: opens in $EDITOR!
     complement: Homebrew bổ sung macOS. Cài gem của bạn với <code>gem</code>, và tất cả các gói phụ thuộc với <code>brew</code>.
+    caskinstall: '"To install, drag this icon..." no more. <code>brew cask</code> installs macOS apps, fonts and plugins and other non-open source software.'
+    caskcreate: Making a cask is as simple as creating a formula.
     install:
       install: Cài đặt Homebrew
       paste: Dán nó vào hiện thị của Terminal.

--- a/_data/locales/zh-cn.yml
+++ b/_data/locales/zh-cn.yml
@@ -11,6 +11,8 @@ zh-cn:
     formula: Homebrew 的配方都是简单的 Ruby 脚本：
     editor: 使用 $EDITOR 编辑!
     complement: Homebrew 使 macOS 更完整。使用 <code>gem</code> 来安装 gems、用 <code>brew</code> 来安装那些依赖包。
+    caskinstall: '"To install, drag this icon..." no more. <code>brew cask</code> installs macOS apps, fonts and plugins and other non-open source software.'
+    caskcreate: Making a cask is as simple as creating a formula.
     install:
       install: 安装 Homebrew
       paste: 将以上命令粘贴至终端。

--- a/_data/locales/zh-tw.yml
+++ b/_data/locales/zh-tw.yml
@@ -11,6 +11,8 @@ zh-tw:
     formula: "Homebrew 的 formula 都是簡單的 Ruby 腳本："
     editor: 使用 $EDITOR 編輯!
     complement: Homebrew 互補了 macOS，你可以使用 <code>gem</code> 來安裝 Ruby 套件， 而它的依存軟體可以用 <code>brew</code> 安裝。
+    caskinstall: '"To install, drag this icon..." no more. <code>brew cask</code> installs macOS apps, fonts and plugins and other non-open source software.'
+    caskcreate: Making a cask is as simple as creating a formula.
     install:
       install: 安裝 Homebrew
       paste: 在終端機命令列提示貼上這個。

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -9,6 +9,7 @@ layout: base
         <h2 id="install">{{ t.pagecontent.install.install }}</h2>
         <br>
         <pre style='clear:both;text-align:center;margin-bottom:0.9em'><code id='selectable' onclick="selectText(this)">/usr/bin/ruby -e &quot;$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)&quot;</code></pre>
+
         <div class="col-1">
           <p>{{ t.pagecontent.install.paste }}</p>
         </div>
@@ -32,6 +33,7 @@ $ brew install wget
         </div>
       </div>
     </li>
+
     <li>
       <div class="group row">
         <div class="col-1">
@@ -51,6 +53,7 @@ bin/wget -> ../Cellar/wget/1.16.1/bin/wget
         </div>
       </div>
     </li>
+
     <li>
       <div class="group row">
         <div class="col-1">
@@ -58,6 +61,7 @@ bin/wget -> ../Cellar/wget/1.16.1/bin/wget
         </div>
       </div>
     </li>
+
     <li>
       <div class="group row">
         <div class="col-1">
@@ -71,6 +75,7 @@ Created /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/bar.rb
         </div>
       </div>
     </li>
+
     <li>
       <div class="group row">
         <div class="col-1">
@@ -83,6 +88,7 @@ $ brew edit wget # {{ t.pagecontent.editor }}
         </div>
       </div>
     </li>
+
     <li>
       <div class="group row">
         <div class="col-1">
@@ -104,10 +110,38 @@ end
         </div>
       </div>
     </li>
+
     <li>
       <div class="group row">
         <div class="col-1">
           <p>{{ t.pagecontent.complement }}</p>
+        </div>
+      </div>
+    </li>
+
+    <li>
+      <div class="group row">
+        <div class="col-1">
+          <p>{{ t.pagecontent.caskinstall }}</p>
+        </div>
+        <div class="col-2">
+{% highlight bash %}
+$ brew cask install firefox
+{% endhighlight %}
+        </div>
+      </div>
+    </li>
+
+    <li>
+      <div class="group row">
+        <div class="col-1">
+          <p>{{ t.pagecontent.caskcreate }}</p>
+        </div>
+        <div class="col-2">
+{% highlight bash %}
+$ brew cask create foo
+Editing /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/foo.rb
+{% endhighlight %}
         </div>
       </div>
     </li>


### PR DESCRIPTION
Add the main contents of https://caskroom.github.io to https://brew.sh.

This should allow the deprecation and redirection of https://caskroom.github.io.

<img width="934" alt="screen shot 2018-06-18 at 20 16 23" src="https://user-images.githubusercontent.com/125011/41557100-8363d232-7334-11e8-924c-b4aeb23c5855.png">

CC @Homebrew/cask maintainers for thoughts on this and what you think are the hard blockers on migrating https://caskroom.github.io to here.