### PR TITLE
Prevent word wrap within command flags on man page

### DIFF
--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -325,6 +325,10 @@ button::-moz-focus-inner {
   pre code {
     font-size: 80%;
   }
+
+  li>p>code {
+    white-space: nowrap;
+  }
 }
 
 #information ul, .posts {


### PR DESCRIPTION
Currently, commands on the [man page](https://docs.brew.sh/Manpage) with a long list of flags can wrap anywhere there's a hyphen. But since each flag is an individual `<code>` element, adding `white-space: nowrap;` to just those elements keeps each flag all on one line, increasing readability. And by using the selector `li>p>code`, this rule applies only to the man page, since the other docs pages do not nest `<p>` elements within `<li>` elements.