### PR TITLE
Bump mention of Lion to Mountain Lion

### DIFF
--- a/_data/locales/ar.yml
+++ b/_data/locales/ar.yml
@@ -16,7 +16,7 @@ ar:
     install:
       install: ثبّت Homebrew
       paste: الصق ذلك في الطرفية
-      what: السكربت سيوضح ماذا سيفعل ثم سيتوقف قبل فعله. هناك خيارات تثبيت اضافية <a href='https://docs.brew.sh/Installation'>هنا</a>, مطلوب للإصدار ١٠.٥ (required for OS X Lion 10.7 and below)
+      what: السكربت سيوضح ماذا سيفعل ثم سيتوقف قبل فعله. هناك خيارات تثبيت اضافية <a href='https://docs.brew.sh/Installation'>هنا</a>, مطلوب للإصدار ١٠.٥ (required for OS X 10.8 Mountain Lion and below)
     doc:
       further: معلومات إضافية
       patreon: Donate on Patreon

--- a/_data/locales/az.yml
+++ b/_data/locales/az.yml
@@ -16,7 +16,7 @@ az:
     install:
       install: Homebrew-i yükləyin
       paste: Bunu Terminal-a əlavə edin.
-      what: Əməliyyatı yerinə yetirməmişdən əvvəl proqram sizə əməliyyat barədə məlumat verir. Daha çox yükləmə üsulları <a href='https://docs.brew.sh/Installation'>buradadır</a> (required for OS X Lion 10.7 and below).
+      what: Əməliyyatı yerinə yetirməmişdən əvvəl proqram sizə əməliyyat barədə məlumat verir. Daha çox yükləmə üsulları <a href='https://docs.brew.sh/Installation'>buradadır</a> (required for OS X 10.8 Mountain Lion and below).
     doc:
       further: Əlavə Sənədlər
       patreon: Patreonda ianə edin

--- a/_data/locales/be.yml
+++ b/_data/locales/be.yml
@@ -16,7 +16,7 @@ be:
     install:
       install: Усталяванне Homebrew
       paste: Скапіруйце і ўстаўце гэта ў тэрмінал.
-      what: Перад выкананнем якога-небудзь дзеянні, скрыпт прыпыніцца і растлумачыць, што ён збіраецца зрабіць. Дадатковыя параметры ўстаноўкі можна знайсці <a href='https://docs.brew.sh/Installation'>тут</a> (required for OS X Lion 10.7 and below).
+      what: Перад выкананнем якога-небудзь дзеянні, скрыпт прыпыніцца і растлумачыць, што ён збіраецца зрабіць. Дадатковыя параметры ўстаноўкі можна знайсці <a href='https://docs.brew.sh/Installation'>тут</a> (required for OS X 10.8 Mountain Lion and below).
     doc:
       further: Дадатковая дакументацыя
       patreon: Donate on Patreon

--- a/_data/locales/ca.yml
+++ b/_data/locales/ca.yml
@@ -16,7 +16,7 @@ ca:
     install:
       install: Instal·la Homebrew
       paste: Enganxa el codi a una finestra de Terminal.
-      what: L'<i>script</i> explica el que fa i s'espera abans de fer-ho. Hi ha més opcions d'instal·lació <a href='https://docs.brew.sh/Installation'>aquí</a> (required for OS X Lion 10.7 and below).
+      what: L'<i>script</i> explica el que fa i s'espera abans de fer-ho. Hi ha més opcions d'instal·lació <a href='https://docs.brew.sh/Installation'>aquí</a> (required for OS X 10.8 Mountain Lion and below).
     doc:
       further: Més Documentació
       patreon: Donate on Patreon

--- a/_data/locales/cs.yml
+++ b/_data/locales/cs.yml
@@ -16,7 +16,7 @@ cs:
     install:
       install: Instalace Homebrew
       paste: Tohle vložte do okna Terminálu.
-      what: Script vysvětlí, co udělá, a než to udělá, pozastaví se. Další možnosti instalace naleznete <a href='https://docs.brew.sh/Installation'>zde</a> (required for OS X Lion 10.7 and below).
+      what: Script vysvětlí, co udělá, a než to udělá, pozastaví se. Další možnosti instalace naleznete <a href='https://docs.brew.sh/Installation'>zde</a> (required for OS X 10.8 Mountain Lion and below).
     doc:
       further: Další dokumentace
       patreon: Donate on Patreon

--- a/_data/locales/da.yml
+++ b/_data/locales/da.yml
@@ -18,7 +18,7 @@ da:
     install:
       install: Installer Homebrew
       paste: Kopier og indsæt i din Terminal
-      what: Scriptet forklarer hvad det vil gøre, og pauser før den gør det. Der findes flere installeringsmuligheder <a href='https://docs.brew.sh/Installation' title="Flere installeringsmuligheder">her</a> (required for OS X Lion 10.7 and below).
+      what: Scriptet forklarer hvad det vil gøre, og pauser før den gør det. Der findes flere installeringsmuligheder <a href='https://docs.brew.sh/Installation' title="Flere installeringsmuligheder">her</a> (required for OS X 10.8 Mountain Lion and below).
     doc:
       further: Videre dokumentation
       patreon: Donate on Patreon

--- a/_data/locales/de.yml
+++ b/_data/locales/de.yml
@@ -16,7 +16,7 @@ de:
     install:
       install: Installiere Homebrew
       paste: Füge das im Terminal ein.
-      what: Das Skript erklärt dir, was es tun wird und wartet, bevor es etwas macht. Mehr Installationsoptionen findest du <a href='https://docs.brew.sh/Installation'>hier</a> (required for OS X Lion 10.7 and below).
+      what: Das Skript erklärt dir, was es tun wird und wartet, bevor es etwas macht. Mehr Installationsoptionen findest du <a href='https://docs.brew.sh/Installation'>hier</a> (required for OS X 10.8 Mountain Lion and below).
     doc:
       further: Weitere Dokumentation
       patreon: Donate on Patreon

--- a/_data/locales/en.yml
+++ b/_data/locales/en.yml
@@ -18,7 +18,7 @@ en:
     install:
       install: Install Homebrew
       paste: Paste that at a Terminal prompt.
-      what: The script explains what it will do and then pauses before it does it. There are more installation options <a href='https://docs.brew.sh/Installation'>here</a> (required for OS X Lion 10.7 and below).
+      what: The script explains what it will do and then pauses before it does it. There are more installation options <a href='https://docs.brew.sh/Installation'>here</a> (required for OS X 10.8 Mountain Lion and below).
     doc:
       further: Further Documentation
       patreon: Donate on Patreon

--- a/_data/locales/es.yml
+++ b/_data/locales/es.yml
@@ -16,7 +16,7 @@ es:
     install:
       install: Instala Homebrew
       paste: Pega este código en una ventana del Terminal.
-      what: El programa de instalación va explicando paso a paso el proceso, qué es lo que va a hacer y se toma una pausa para confirmar antes de empezar con cada uno de los pasos. Puedes encontrar más opciones de instalación <a href='https://docs.brew.sh/Installation'>aquí</a> (required for OS X Lion 10.7 and below).
+      what: El programa de instalación va explicando paso a paso el proceso, qué es lo que va a hacer y se toma una pausa para confirmar antes de empezar con cada uno de los pasos. Puedes encontrar más opciones de instalación <a href='https://docs.brew.sh/Installation'>aquí</a> (required for OS X 10.8 Mountain Lion and below).
     doc:
       further: Documentos adicionales
       patreon: Dona con Patreon

--- a/_data/locales/fa.yml
+++ b/_data/locales/fa.yml
@@ -16,7 +16,7 @@ fa:
     install:
       install: نصب Homebrew
       paste: کد بالا را در خط فرمان ترمینال جایگذاری کنید.
-      what: اسکریپت قبل از انجام هر مرحله مکث کرده و به توضیح کاری که می‌خواهد انجام دهد می‌پردازد. گزینه‌های بیشتری برای نصب <a href='https://docs.brew.sh/Installation'>اینجا</a>  موجود است. نسخه ۱۰.۵ نیاز است. (required for OS X Lion 10.7 and below)
+      what: اسکریپت قبل از انجام هر مرحله مکث کرده و به توضیح کاری که می‌خواهد انجام دهد می‌پردازد. گزینه‌های بیشتری برای نصب <a href='https://docs.brew.sh/Installation'>اینجا</a>  موجود است. نسخه ۱۰.۵ نیاز است. (required for OS X 10.8 Mountain Lion and below)
     doc:
       further: مستندات بیشتر
       patreon: Donate on Patreon

--- a/_data/locales/fi.yml
+++ b/_data/locales/fi.yml
@@ -16,7 +16,7 @@ fi:
     install:
       install: Asenna Homebrew
       paste: Liitä tämä komentokehotteeseen.
-      what: Skripti kertoo mitä tekee ja pysähtyy sen jälkeen odottamaan varmistusta. Lisää asennusvaihtoehtoja löytyy <a href='https://docs.brew.sh/Installation'>täältä</a> (required for OS X Lion 10.7 and below).
+      what: Skripti kertoo mitä tekee ja pysähtyy sen jälkeen odottamaan varmistusta. Lisää asennusvaihtoehtoja löytyy <a href='https://docs.brew.sh/Installation'>täältä</a> (required for OS X 10.8 Mountain Lion and below).
     doc:
       further: Laajempi dokumentaatio
       patreon: Donate on Patreon

--- a/_data/locales/fr.yml
+++ b/_data/locales/fr.yml
@@ -16,7 +16,7 @@ fr:
     install:
       install: Installer Homebrew
       paste: Copiez et collez dans une fenêtre du Terminal.
-      what: Le script explique ce qu’il va faire, puis fait une pause avant de l’exécuter. Plus d’options d’installation sont disponibles <a href="https://docs.brew.sh/Installation">ici</a> (required for OS X Lion 10.7 and below).
+      what: Le script explique ce qu’il va faire, puis fait une pause avant de l’exécuter. Plus d’options d’installation sont disponibles <a href="https://docs.brew.sh/Installation">ici</a> (required for OS X 10.8 Mountain Lion and below).
     doc:
       further: Documentation additionnelle
       patreon: Donate on Patreon

--- a/_data/locales/gl.yml
+++ b/_data/locales/gl.yml
@@ -16,7 +16,7 @@ gl:
     install:
       install: Instala Homebrew
       paste: Pega este código nunha Terminal.
-      what: O <i>script</i> explica o que vai facer e fai unha pausa antes de executar nada. Hai máis opcións de instalación <a href='https://docs.brew.sh/Installation'>aquí</a> (required for OS X Lion 10.7 and below).
+      what: O <i>script</i> explica o que vai facer e fai unha pausa antes de executar nada. Hai máis opcións de instalación <a href='https://docs.brew.sh/Installation'>aquí</a> (required for OS X 10.8 Mountain Lion and below).
     doc:
       further: Documentación adicional
       patreon: Doa en Patreon

--- a/_data/locales/he.yml
+++ b/_data/locales/he.yml
@@ -16,7 +16,7 @@ he:
     install:
       install: התקנת Homebrew
       paste: הדביקו את הנ״ל ב-Terminal.
-      what: הסקריפט יסביר מה הוא יעשה ויעצור לפני שיעשה זאת. קיימות אופציות התקנה נוספות <a href='https://docs.brew.sh/Installation'>כאן</a> (required for OS X Lion 10.7 and below).
+      what: הסקריפט יסביר מה הוא יעשה ויעצור לפני שיעשה זאת. קיימות אופציות התקנה נוספות <a href='https://docs.brew.sh/Installation'>כאן</a> (required for OS X 10.8 Mountain Lion and below).
     doc:
       further: דוקומנטציה נוספת
       patreon: Donate on Patreon

--- a/_data/locales/it.yml
+++ b/_data/locales/it.yml
@@ -16,7 +16,7 @@ it:
     install:
       install: Installa Homebrew
       paste: Incolla questa riga su una finestra del Terminale.
-      what: Lo script ti spiega quello che sta facendo e aspetterà un tuo comando. Ci sono ulteriori <a href='https://docs.brew.sh/Installation'>opzioni di installazione</a> (required for OS X Lion 10.7 and below).
+      what: Lo script ti spiega quello che sta facendo e aspetterà un tuo comando. Ci sono ulteriori <a href='https://docs.brew.sh/Installation'>opzioni di installazione</a> (required for OS X 10.8 Mountain Lion and below).
     doc:
       further: Ulteriore documentazione
       patreon: Donate on Patreon

--- a/_data/locales/ja.yml
+++ b/_data/locales/ja.yml
@@ -16,7 +16,7 @@ ja:
     install:
       install: インストール
       paste: このスクリプトをターミナルに貼り付け実行して下さい。
-      what: スクリプトは何をするのか説明し、実際にインストールを実行する前に一度中断します。<a href='https://docs.brew.sh/Installation'>こちら</a>でインストールオプションを確認できます (required for OS X Lion 10.7 and below)。
+      what: スクリプトは何をするのか説明し、実際にインストールを実行する前に一度中断します。<a href='https://docs.brew.sh/Installation'>こちら</a>でインストールオプションを確認できます (required for OS X 10.8 Mountain Lion and below)。
     doc:
       further: さらに詳しいドキュメント
       patreon: Donate on Patreon

--- a/_data/locales/ko.yml
+++ b/_data/locales/ko.yml
@@ -16,7 +16,7 @@ ko:
     install:
       install: Homebrew 설치하기
       paste: 터미널에 붙여넣기 하세요.
-      what: 해당 스크립트는 무엇을 할지 설명하고 실행하기 전에 잠시 멈춥니다. 더 자세한 설치 관련사항을 보려면 <a href='https://docs.brew.sh/Installation'>여기</a>를 참고하세요 (required for OS X Lion 10.7 and below).
+      what: 해당 스크립트는 무엇을 할지 설명하고 실행하기 전에 잠시 멈춥니다. 더 자세한 설치 관련사항을 보려면 <a href='https://docs.brew.sh/Installation'>여기</a>를 참고하세요 (required for OS X 10.8 Mountain Lion and below).
     doc:
       further: 추가 문서
       patreon: Patreon에 기부

--- a/_data/locales/nl.yml
+++ b/_data/locales/nl.yml
@@ -16,7 +16,7 @@ nl:
     install:
       install: Installeer Homebrew
       paste: Plak het bovenstaande in Terminal.
-      what: Het installatiescript beschrijft wat het wilt doen en wacht voordat de installatie wordt uitgevoerd. Meer installatie-opties zijn <a href='https://docs.brew.sh/Installation'>hier</a> (required for OS X Lion 10.7 and below).
+      what: Het installatiescript beschrijft wat het wilt doen en wacht voordat de installatie wordt uitgevoerd. Meer installatie-opties zijn <a href='https://docs.brew.sh/Installation'>hier</a> (required for OS X 10.8 Mountain Lion and below).
     doc:
       further: Verdere documentatie
       patreon: Donate on Patreon

--- a/_data/locales/no.yml
+++ b/_data/locales/no.yml
@@ -16,7 +16,7 @@
     install:
       install: Installer Homebrew
       paste: Lim dette inn i din Terminal.
-      what: Scriptet forklarer hva det gjør og tar en pause før det gjøres. Du finner flere måter å installere på <a href='https://docs.brew.sh/Installation'>her</a> (required for OS X Lion 10.7 and below).
+      what: Scriptet forklarer hva det gjør og tar en pause før det gjøres. Du finner flere måter å installere på <a href='https://docs.brew.sh/Installation'>her</a> (required for OS X 10.8 Mountain Lion and below).
     doc:
       further: Videre dokumentasjon
       patreon: Donate on Patreon

--- a/_data/locales/pl.yml
+++ b/_data/locales/pl.yml
@@ -16,7 +16,7 @@ pl:
     install:
       install: Zainstaluj Homebrewa
       paste: Wklej polecenie w swoim Terminalu.
-      what: Skrypt instalacyjny wyjaśnia jakie zmiany zamierza wprowadzić, po czym zatrzymuje się czekając na ich akceptację. Po więcej opcji instalacji zajrzyj <a href='https://docs.brew.sh/Installation'>tutaj</a> (required for OS X Lion 10.7 and below).
+      what: Skrypt instalacyjny wyjaśnia jakie zmiany zamierza wprowadzić, po czym zatrzymuje się czekając na ich akceptację. Po więcej opcji instalacji zajrzyj <a href='https://docs.brew.sh/Installation'>tutaj</a> (required for OS X 10.8 Mountain Lion and below).
     doc:
       further: Dalsza dokumentacja
       patreon: Donate on Patreon

--- a/_data/locales/pt-br.yml
+++ b/_data/locales/pt-br.yml
@@ -16,7 +16,7 @@ pt-br:
     install:
       install: Instale o Homebrew
       paste: Copie esse código para um prompt do seu Terminal.
-      what: O script explica o que irá fazer e faz uma pausa antes de ser executado. Há mais opções de instalação <a href='https://docs.brew.sh/Installation'>aqui</a> (required for OS X Lion 10.7 and below).
+      what: O script explica o que irá fazer e faz uma pausa antes de ser executado. Há mais opções de instalação <a href='https://docs.brew.sh/Installation'>aqui</a> (required for OS X 10.8 Mountain Lion and below).
     doc:
       further: Documentos Adicionais
       patreon: Donate on Patreon

--- a/_data/locales/ro.yml
+++ b/_data/locales/ro.yml
@@ -16,7 +16,7 @@ ro:
     install:
       install: Instalează Homebrew
       paste: Copiază această comandă în terminal.
-      what: Script-ul îți va explica ce vrea să facă și va lua o pauză înainte de a continua. Poți găsi mai multe opțiuni de instalare <a href='https://docs.brew.sh/Installation'>în documentație</a> (required for OS X Lion 10.7 and below).
+      what: Script-ul îți va explica ce vrea să facă și va lua o pauză înainte de a continua. Poți găsi mai multe opțiuni de instalare <a href='https://docs.brew.sh/Installation'>în documentație</a> (required for OS X 10.8 Mountain Lion and below).
     doc:
       further: Documentație amănunțită
       patreon: Donații Patreon

--- a/_data/locales/sr.yml
+++ b/_data/locales/sr.yml
@@ -16,7 +16,7 @@ sr:
     install:
       install: Инсталирај Homebrew
       paste: Налепите ово у прозор Терминала.
-      what: Скрипта ће да се паузира и објасни шта ради пре него што то и уради. Више опција за инсталацију постоји <a href='https://docs.brew.sh/Installation'>овде</a> (required for OS X Lion 10.7 and below).
+      what: Скрипта ће да се паузира и објасни шта ради пре него што то и уради. Више опција за инсталацију постоји <a href='https://docs.brew.sh/Installation'>овде</a> (required for OS X 10.8 Mountain Lion and below).
     doc:
       further: Даља Документација
       patreon: Donate on Patreon

--- a/_data/locales/sv.yml
+++ b/_data/locales/sv.yml
@@ -16,7 +16,7 @@ sv:
     install:
       install: Installera Homebrew
       paste: Klistra in det här i Terminal.app.
-      what: Skriptet förklarar vad det kommer att installera och pausar före installationen. Det finns fler installationsalternativ <a href='https://docs.brew.sh/Installation'>här</a> (required for OS X Lion 10.7 and below).
+      what: Skriptet förklarar vad det kommer att installera och pausar före installationen. Det finns fler installationsalternativ <a href='https://docs.brew.sh/Installation'>här</a> (required for OS X 10.8 Mountain Lion and below).
     doc:
       further: Vidare Dokumentation
       patreon: Donate on Patreon

--- a/_data/locales/th.yml
+++ b/_data/locales/th.yml
@@ -16,7 +16,7 @@ th:
     install:
       install: วิธีการติดตั้ง Homebrew
       paste: คัดลอกคำสั่งด้านบนไปรันใน Terminal
-      what: สคริปจะมีการอธิบายให้รู้ก่อนว่ากำลังจะทำอะไร จากนั้นจะหยุดถามก่อนที่มันจะเริ่มทำ สามารถดูตัวเลือกในการติดตั้งต่าง ๆ ได้จาก<a href='https://docs.brew.sh/Installation'>ที่นี่</a> (required for OS X Lion 10.7 and below)
+      what: สคริปจะมีการอธิบายให้รู้ก่อนว่ากำลังจะทำอะไร จากนั้นจะหยุดถามก่อนที่มันจะเริ่มทำ สามารถดูตัวเลือกในการติดตั้งต่าง ๆ ได้จาก<a href='https://docs.brew.sh/Installation'>ที่นี่</a> (required for OS X 10.8 Mountain Lion and below)
     doc:
       further: เอกสารอื่น ๆ
       patreon: Donate on Patreon

--- a/_data/locales/tr.yml
+++ b/_data/locales/tr.yml
@@ -16,7 +16,7 @@ tr:
     install:
       install: Homebrew'i yükleyin
       paste: Üstteki kod parçacığını bir Terminal penceresine yapıştırın.
-      what: Betik yapacaklarını açıklayıp, sizden komut bekler. <a href="https://docs.brew.sh/Installation">Burada</a> başka kurulum seçenekleri de bulabilirsiniz (required for OS X Lion 10.7 and below).
+      what: Betik yapacaklarını açıklayıp, sizden komut bekler. <a href="https://docs.brew.sh/Installation">Burada</a> başka kurulum seçenekleri de bulabilirsiniz (required for OS X 10.8 Mountain Lion and below).
     doc:
       further: İlave Dökümantasyon
       patreon: Patreon'da bağış yapın

--- a/_data/locales/uk.yml
+++ b/_data/locales/uk.yml
@@ -16,7 +16,7 @@ uk:
     install:
       install: Встановлення Homebrew
       paste: Запустіть цей код в Terminal.
-      what: Перш ніж робити будь-які зміни, скрипт зупиниться для пояснення, що саме буде зроблено. Більше способів установлення описані <a href='https://docs.brew.sh/Installation'>тут</a> (required for OS X Lion 10.7 and below).
+      what: Перш ніж робити будь-які зміни, скрипт зупиниться для пояснення, що саме буде зроблено. Більше способів установлення описані <a href='https://docs.brew.sh/Installation'>тут</a> (required for OS X 10.8 Mountain Lion and below).
     doc:
       further: Більше документації
       patreon: Donate on Patreon

--- a/_data/locales/vi.yml
+++ b/_data/locales/vi.yml
@@ -16,7 +16,7 @@ vi:
     install:
       install: Cài đặt Homebrew
       paste: Dán nó vào hiện thị của Terminal.
-      what: Đoạn script giải thích các bước sẽ được thực hiện và sẽ dừng trước khi thực thi. Có nhiều lựa chọn cài đặt <a href='https://docs.brew.sh/Installation'>ở đây</a> (required for OS X Lion 10.7 and below).
+      what: Đoạn script giải thích các bước sẽ được thực hiện và sẽ dừng trước khi thực thi. Có nhiều lựa chọn cài đặt <a href='https://docs.brew.sh/Installation'>ở đây</a> (required for OS X 10.8 Mountain Lion and below).
     doc:
       further: Tra khảo thêm
       patreon: Donate on Patreon

--- a/_data/locales/zh-cn.yml
+++ b/_data/locales/zh-cn.yml
@@ -16,7 +16,7 @@ zh-cn:
     install:
       install: 安装 Homebrew
       paste: 将以上命令粘贴至终端。
-      what: 脚本会在执行前暂停，并说明将它将做什么。高级安装选项在 <a href='https://docs.brew.sh/Installation'>这里</a> (required for OS X Lion 10.7 and below)。
+      what: 脚本会在执行前暂停，并说明将它将做什么。高级安装选项在 <a href='https://docs.brew.sh/Installation'>这里</a> (required for OS X 10.8 Mountain Lion and below)。
     doc:
       further: 更多文档
       patreon: Donate on Patreon

--- a/_data/locales/zh-tw.yml
+++ b/_data/locales/zh-tw.yml
@@ -16,7 +16,7 @@ zh-tw:
     install:
       install: 安裝 Homebrew
       paste: 在終端機命令列提示貼上這個。
-      what: 腳本執行時會解釋它正在做什麼，並在你確認之前暫停下來。你可以在<a href='https://docs.brew.sh/Installation'>這裡</a>找到更多安裝選擇 (required for OS X Lion 10.7 and below)。
+      what: 腳本執行時會解釋它正在做什麼，並在你確認之前暫停下來。你可以在<a href='https://docs.brew.sh/Installation'>這裡</a>找到更多安裝選擇 (required for OS X 10.8 Mountain Lion and below)。
     doc:
       further: 更多說明文件
       patreon: Donate on Patreon


### PR DESCRIPTION
Extra steps are also required for Mountain Lion due to its lack of TLS 1.2 support.

Paired with Homebrew/brew#5238.