### PR TITLE
Add Norwegian Nynorsk locale

### DIFF
--- a/_data/locales/nb.yml
+++ b/_data/locales/nb.yml
@@ -1,5 +1,5 @@
-"no":
-  locale_name: Norsk
+nb:
+  locale_name: Norsk bokmål
   subtitle: macOS’ manglende pakkebehandler
   pagecontent:
     question: What Does Homebrew Do?

--- a/_data/locales/nn.yml
+++ b/_data/locales/nn.yml
@@ -1,0 +1,29 @@
+nn:
+  locale_name: Norsk nynorsk
+  subtitle: MacOS sin manglande pakkehandsamar
+  pagecontent:
+    question: Kva gjer Homebrew?
+    what: Homebrew installerer <a href="https://formulae.brew.sh/formula/" title="Liste over Homebrew-pakkar">alt du treng</a> som Apple ikkje installerte.
+    how: Homebrew installerer pakkar i eigne mapper, og symlenker filene i <code>/usr/local</code>.
+    prefix: Homebrew installerer ikkje filer utanfor området sitt, og du kan plassere ein Homebrew-installasjon kor som helst.
+    createpackages: Lag dine eigne Homebrew-pakkar, enkelt.
+    hack: Alt er Git og Ruby under overflata, så du kan hacke i veg – vel vitande om at du enkelt kan reversere endringane dine og flette inn oppdateringar frå andre.
+    formula: "Homebrew-formlar er enkle Ruby-skript:"
+    editor: opnar i $EDITOR!
+    complement: Homebrew er eit tillegg til macOS. Installer gems sjølv med <code>gem</code>, og pakkane dei er avhengig av med <code>brew</code>.
+    caskinstall: 'Endeleg slutt på "To install, drag this icon...". <code>brew cask</code> installerer macOS-appar, fontar og plugins og anna programvare som ikkje er open-kjeldekode.'
+    caskcreate: Å lage ein cask er like enkelt som å lage ein formel.
+    install:
+      install: Installer Homebrew
+      paste: Lim dette inn i terminalen din.
+      what: Skriptet forklarar kva det gjer og tek ei pause før det køyrer. Du finn fleire måtar å installere på <a href='https://docs.brew.sh/Installation'>her</a> (påtvunge for OS X 10.8 Mountain Lion eller tidlegare versjonar).
+    doc:
+      further: Vidare dokumentasjon
+      donate: Støtt Homebrew
+      blog: Homebrew Blogg
+      community: Community-forum
+      formulae: Homebrew Packages
+      analytics: Analytics Data
+    foot:
+      code: Homebrew vart laga av <a href="https://mxcl.github.io/">Max Howell</a>.
+      page: Nettside av <a href="https://www.exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> og <a href="https://danilalo.com/">Danielle Lalonde</a>.

--- a/index_nb.html
+++ b/index_nb.html
@@ -1,4 +1,4 @@
 ---
 layout: index
-lang: "no"
+lang: "nb"
 ---

--- a/index_nn.html
+++ b/index_nn.html
@@ -1,0 +1,4 @@
+---
+layout: index
+lang: "nn"
+---


### PR DESCRIPTION
This adds Norwegian Nynorsk (`nn`) as a locale for Brew.sh, and moves the existing Norwegian Bokmål (`nb`) to the correct locale (from `no` to `nb`). 

_Some additional info: Spoken Norwegian is represented by two official written languages, Nynorsk and Bokmål. The changes are made according to [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)._