### PR TITLE
azure-pipelines: use bundler v1.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ steps:
     versionSpec: '>= 2.3'
 
 - script: |
-    gem install bundler
+    gem install bundler --version '<2'
     bundle install --retry=3 --jobs=4
   displayName: 'bundle install'
 


### PR DESCRIPTION
Bundler v2.0.0 is failing to install.