### PR TITLE
Add github like header linking to page layout

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -114,5 +114,12 @@
         }
       }
     </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/4.2.0/anchor.min.js" 
+            integrity="sha256-m1eTvwEHwmsw4+XKF7BshClVJEPwTVycveNl0CS0Mkk=" 
+            crossorigin="anonymous"></script>
+    <script type="text/javascript">
+      anchors.options.placement = 'left';
+      anchors.add('.page > h2, .page > h3, .page > h4, .page > h5, .page > h6');
+    </script>
   </body>
 </html>


### PR DESCRIPTION
Uses https://github.com/bryanbraun/anchorjs/ to automatically add a link icon to headers.
This will make it a lot easier to point users to the specific part of the docs they missed.