### PR TITLE
Enable anchors on touch devices and cleanup loading

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -113,13 +113,18 @@
             window.location.assign("/index_" + lang);
         }
       }
+
+      function loadAnchors() {
+        anchors.options = {
+          placement: 'left',
+          visible: 'touch',
+        };
+        anchors.add('#page > h2, #page > h3, #page > h4, #page > h5, #page > h6');
+      }
     </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/4.2.0/anchor.min.js" 
             integrity="sha256-m1eTvwEHwmsw4+XKF7BshClVJEPwTVycveNl0CS0Mkk=" 
-            crossorigin="anonymous"></script>
-    <script type="text/javascript">
-      anchors.options.placement = 'left';
-      anchors.add('#page > h2, #page > h3, #page > h4, #page > h5, #page > h6');
-    </script>
+            crossorigin="anonymous"
+            onload="loadAnchors()" async></script>
   </body>
 </html>


### PR DESCRIPTION
This will always show the anchors on touch/mobile devices and it'll change the loading of the library to be async.