### PR TITLE
fix appearance of form elements in Gecko

### DIFF
--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -298,9 +298,19 @@ button::-moz-focus-inner {
 }
 
 #language {
-  font-size: 104%;
-  font-size-adjust: 0.47;
+  font-size: 16px;
   margin: 1em 0;
+}
+
+#search-bar {
+  width: 17em;
+  margin: 0.1em;
+  padding: 0.1em;
+  font-size: 15px;
+  border: 1px solid #222;
+  border-radius: 4px;
+  text-align: center;
+  -webkit-appearance: none;
 }
 
 #selectable {
@@ -562,18 +572,6 @@ span .amp {
   [dir="rtl"] #information .row .col-2 {
     float: right;
   }
-}
-
-#search-bar {
-  width: 17em;
-  margin: 0.1em;
-  padding: 0 0.1em;
-  font-size: 88%;
-  height: 22px;
-  border: 1px solid #222;
-  border-radius: 4px;
-  text-align: center;
-  -webkit-appearance: none;
 }
 
 /* Main dropdown wrapper */

--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -298,7 +298,8 @@ button::-moz-focus-inner {
 }
 
 #language {
-  font-size: 150%;
+  font-size: 104%;
+  font-size-adjust: 0.47;
   margin: 1em 0;
 }
 
@@ -564,11 +565,15 @@ span .amp {
 }
 
 #search-bar {
-  width: 10em;
+  width: 17em;
   margin: 0.1em;
-  padding: 0.1em;
-  font-size: 150%;
+  padding: 0 0.1em;
+  font-size: 88%;
+  height: 22px;
+  border: 1px solid #222;
+  border-radius: 4px;
   text-align: center;
+  -webkit-appearance: none;
 }
 
 /* Main dropdown wrapper */


### PR DESCRIPTION
The problem arises becase Safari defaults to applying `-webkit-appearance: searchfield` to the search field, which causes its font size to shrink from 15px to 11px. This also shrinks the width, which is sized using ems. Increasing the field's `font-size` percentage bumps its font size to 13px after 103%, and after that just increases the width. Firefox, on the other hand, does not automatically apply `-moz-appearance: searchfield` and applies the `font-size: 150%` exactly as specified, so the search field looks like an oversized text field. The language dropdown is similarly affected.

This is fixed in Firefox by applying a browser hack that shrinks the font size for both the search field and language dropdown and corrects the width.