### PR TITLE
layouts/base: allow customising page logo.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.formatOnSave": false
+}

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -51,7 +51,13 @@
   <body>
     <div id="wrap">
       <div id="header" class="{{ page.header-class }}">
+        {% if page.logo %}
+        <img alt="{{ page.title }} logo" src="{{ site.baseurl }}{{ page.logo }}" width="128" height="128">
+        {% elsif site.logo %}
+        <img alt="{{ site.title }} logo" src="{{ site.baseurl }}{{ site.logo }}" width="128" height="128">
+        {% else %}
         <img alt="Homebrew logo" src="{{ site.baseurl }}/assets/img/homebrew-256x256.png" width="128" height="128">
+        {% endif %}
         <h1><a href="{{ site.baseurl }}/">{{ site.title }}</a></h1>
         {% if t.subtitle %}
         <p id="subtitle"><strong>{{ t.subtitle }}</strong></p>

--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -194,6 +194,10 @@ table {
   width: 100%;
 }
 
+div .highlight {
+  margin-top: 0;
+}
+
 pre {
   margin: 0 0 1em 0;
   background: $black_30;


### PR DESCRIPTION
This allows individual sites and pages to customise their logos.

Also, don't let VS Code autoformat on save (because it breaks everything).