### PR TITLE
css: fix ul on mobile

### DIFF
--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -522,7 +522,7 @@ span .amp {
   }
 
   ul {
-    margin: 0;
+    margin-left: 0;
     padding: 0;
     padding-left: 1em;
   }


### PR DESCRIPTION
On mobile screens, unordered lists lack the 1em padding at the end that
other paragraphs have. Add this padding for better visual flow.