### PR TITLE
Correctly set default placeholder text for search box

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -68,7 +68,7 @@
             type="search"
             name="search-bar"
             id="search-bar"
-            placeholder="{{ t.pagecontent.search }} {% if page.search_name %}{{ page.search_name }}{% else %}Homebrew{% endif %}"
+            placeholder="{% if t.pagecontent.search %}{{ t.pagecontent.search }}{% else %}Search{% endif %} {% if page.search_name %}{{ page.search_name }}{% else %}Homebrew{% endif %}"
           />
         </div>
 


### PR DESCRIPTION
On a release page like https://brew.sh/2019/11/27/homebrew-2.2.0/ the search box placeholder text is missing the word `Search`:

<img width="383" alt="Screen Shot 2019-11-27 at 10 43 21 AM" src="https://user-images.githubusercontent.com/123345/69739667-1cdddf00-1106-11ea-9d52-6f255f6e66dd.png">

This leads to strange UX. I was unsure what that white box was for until I clicked it. Then I realized it was a search box.

The bug appears to be caused by some localization issue. On the English release page `t.pagecontent.search` is not set and no default value is provided in the template.

This updates the template to default to `Search Homebrew` for the placeholder text if a localized string is not provided.

<img width="399" alt="Screen Shot 2019-11-27 at 11 09 58 AM" src="https://user-images.githubusercontent.com/123345/69739896-780fd180-1106-11ea-9a96-0c13e6078563.png">
