### PR TITLE
Title Case "the missing package manager for macOS" description

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 title: Homebrew
-description: The missing package manager for macOS (or Linux).
+description: The Missing Package Manager for macOS (or Linux).
 
 exclude:
   - bin

--- a/_data/locales/en.yml
+++ b/_data/locales/en.yml
@@ -1,6 +1,6 @@
 en:
   locale_name: English
-  subtitle: The missing package manager for macOS (or Linux)
+  subtitle: The Missing Package Manager for macOS (or Linux)
   pagecontent:
     search: Search
     question: What Does Homebrew Do?


### PR DESCRIPTION
- This makes the styles here consistent with Homebrew/brew and brew(1).
- See https://github.com/Homebrew/brew/pull/6826 for further context.