### PR TITLE
CI: Lint blog posts with Vale

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,3 +22,16 @@ jobs:
 
     - name: Run HTML Proofer tests
       run: bundle exec rake test
+
+  vale:
+    runs-on: ubuntu-latest
+    container:
+      image: homebrew/brew:latest
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@master
+
+      - name: Run Vale linting on Markdown files
+        run: |
+          brew install vale
+          vale --config=$(brew --repo)/.vale.ini _posts/


### PR DESCRIPTION
- Requested in https://github.com/Homebrew/brew/pull/6826#issuecomment-564450052.
- Using the styles in Homebrew/brew, run Vale docs linting on blog posts here.
- I went for the easy approach by using a macOS runner for this as it already has Homebrew installed.