### PR TITLE
index: use Bash installer.

### DIFF
--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -8,7 +8,7 @@ layout: base
       <div class="group row">
         <h2 id="install">{{ t.pagecontent.install.install }}</h2>
         <br>
-        <pre style='clear:both;text-align:center;margin-bottom:0.9em'><code id='selectable' onclick="selectText(this)">/usr/bin/ruby -e &quot;$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)&quot;</code></pre>
+        <pre style='clear:both;text-align:center;margin-bottom:0.9em'><code id='selectable' onclick="selectText(this)">/bin/bash -c &quot;$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)&quot;</code></pre>
 
         <div class="col-1">
           <p>{{ t.pagecontent.install.paste }}</p>


### PR DESCRIPTION
When https://github.com/Homebrew/install/pull/256 is merged the Ruby installer will have been deprecated and replaced.