### PR TITLE
Homebrew 1.2.0: remove Homebrew/versions link.

### DIFF
--- a/_posts/2017-05-01-homebrew-1.2.0.md
+++ b/_posts/2017-05-01-homebrew-1.2.0.md
@@ -4,7 +4,7 @@ author: MikeMcQuaid
 ---
 Today I'd like to announce Homebrew 1.2.0. The most significant change since 1.1.0 is that most Homebrew taps (package repositories) in the [Homebrew GitHub organisation](https://github.com/Homebrew) have been deprecated and the currently buildable software moved into [Homebrew/homebrew-core](https://github.com/Homebrew/homebrew-core). This will improve the quality and availability of all their software.
 
-Additionally, as [Homebrew/homebrew-versions](https://github.com/Homebrew/homebrew-versions) has been moved into [Homebrew/homebrew-core](https://github.com/Homebrew/homebrew-core) Homebrew provides better, official support for different versions. You can read more about this in the [dedicated versions document](https://docs.brew.sh/Versions.html). Please note our goal isn't to support all versions of all software but to provide some versions and tooling such that you can easily maintain more in your [own tap (package repository)](https://docs.brew.sh/How-to-Create-and-Maintain-a-Tap).
+Additionally, as Homebrew/homebrew-versions has been moved into [Homebrew/homebrew-core](https://github.com/Homebrew/homebrew-core) Homebrew provides better, official support for different versions. You can read more about this in the [dedicated versions document](https://docs.brew.sh/Versions.html). Please note our goal isn't to support all versions of all software but to provide some versions and tooling such that you can easily maintain more in your [own tap (package repository)](https://docs.brew.sh/How-to-Create-and-Maintain-a-Tap).
 
 Since 1.1.0 the following deprecations have been made:
 


### PR DESCRIPTION
The repo was old enough that it was removed.