### PR TITLE
CI cleanup

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,11 +13,11 @@ jobs:
     - name: Set up Ruby
       uses: actions/setup-ruby@v1
       with:
-        version: '>=2.3'
+        ruby-version: 2.6
 
     - name: Install RubyGems
       run: |
-        gem install bundler
+        gem install bundler -v "~>1"
         bundle install --jobs 4 --retry 3
 
     - name: Run HTML Proofer tests

--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ task test: :build do
     "./_site",
     parallel: { in_threads: 4 },
     favicon: true,
-    http_status_ignore: [0],
+    http_status_ignore: [0, 302, 303, 429, 521],
     assume_extension: true,
     check_external_hash: true,
     check_favicon: true,


### PR DESCRIPTION
- Use Ruby 2.6
- Use Bundler 1.x (as comes with Ruby 2.6)
- Ignore more "not an error" HTTP status codes