### PR TITLE
Extract hardcoded algolia docsearch configuration to layout front-matter

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -1,3 +1,9 @@
+---
+algolia:
+  apiKey: a57ef92bf2adfae863a201ee43d6b5a1
+  indexName: brew_all
+  inputSelector: '#search-bar'
+---
 {% assign t = site.data.locales[page.lang][page.lang] %}
 <!DOCTYPE html>
 <html {% if page.direction == "rtl" %}dir="rtl" {% endif %}lang="{{ page.lang }}">
@@ -139,15 +145,10 @@
       };
 
       function loadSearch(lang, site) {
-        docsearch({
-          apiKey:'a57ef92bf2adfae863a201ee43d6b5a1',
-          indexName: 'brew_all',
-          inputSelector: '#search-bar',
-          algoliaOptions: { 'facetFilters': [
-            'lang: ' + lang,
-            'site: ' + site,
-          ]}
-        });
+        docsearch(Object.assign(
+          { algoliaOptions: { facetFilters: ['lang: ' + lang, 'site: ' + site] } },
+          {{ layout.algolia | jsonify }}
+        ));
       };
     </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/4.2.0/anchor.min.js"


### PR DESCRIPTION
This allows inheriting layouts to override the config as necessary.

The `algoliaOptions.facetFilters` property is kept as the base object into which the other properties will be merged. This is because the `lang/site` facets are presently being defined using the loadSearch params. Keeping them in the base allows existing layouts to not be changed.

An example of what this change enables is in this PR: https://github.com/nodenv/formulae/pull/13

In particular, with this change, forks of formulae.brew.sh (or really, any jekyll/github-pages site which uses brew.sh as its remote theme) will be able to point the seach box to their _own_ algolia docsearch index.

The magic is accomplished by third party sites creating their own layout which inherits from this theme's `base` layout. The two algolia front-matters are _merged_ (with the inheriting template's front-matter taking precedence), thus other sites can override the aloglia apiKey, index, etc. Note here that our algolia configuration does not override the `inputSelector: '#search-bar'`, which is still taken from brew.sh's base template front-matter. (since we're still targeting the same html input element)

```html
---
 # base layout from Homebrew/brew.sh theme
 layout: base
 algolia:
   apiKey: e07da24fca504608d6a9d72caf4363c4
   indexName: brew_nodenv
 ---
 <div id="default">
   {{ content }}
 </div>
```

A point of complication: ideally I would have liked the _entire_ algolia configuration to have been defined within the front-matter (that is, the `alogliaOptions.facetFilters` props). However, because they are configured dynamically via JS, I had to leave them "hardcoded". However, the front-matter props are merged into the hardcoded props using `Object.assign`. Which means other sites would be _able_ to specify their properties via front-matter, if those properties could be defined at build-time instead of run-time.

Worth noting here, since all current usages of this theme (formula.brew.sh for one) are already inheriting this configuration as the hardcoded values, none of the other sites need to change. The defaults are still provided by means of the front-matter in this template.

The effect of this PR is already live and powering [nodenv's formulae browser](https://nodenv.github.io/formulae/) because we are presently pointing to https://github.com/jasonkarns/brew.sh's master (the HEAD of this PR) for the remote theme.

see https://github.com/nodenv/formulae/blob/master/_layouts/nodenv_default.html and https://github.com/nodenv/formulae/blob/master/_config.yml#L6