### PR TITLE
Use relative_url filter to support subpath-hosted sites

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -23,9 +23,9 @@ algolia:
     {% seo title=false %}
     {% feed_meta %}
     <meta name="viewport" content="width=device-width">
-    <link rel="icon" type="image/x-icon" href="{{ site.baseurl }}/assets/img/favicon.ico">
-    <link rel="apple-touch-icon" href="{{ site.baseurl }}/assets/img/apple-touch-icon.png">
-    <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/styles.css" type="text/css" media="screen">
+    <link rel="icon" type="image/x-icon" href="{{ "/assets/img/favicon.ico" | relative_url }}">
+    <link rel="apple-touch-icon" href="{{ "/assets/img/apple-touch-icon.png" | relative_url }}">
+    <link rel="stylesheet" href="{{ "/assets/css/styles.css" | relative_url }}" type="text/css" media="screen">
     {% if site.url == "http://localhost:4000" %}
     <script src="https://github.com/Khan/tota11y/releases/download/0.1.3/tota11y.min.js"></script>
     {% endif %}
@@ -58,11 +58,11 @@ algolia:
     <div id="wrap">
       <div id="header" class="{{ page.header-class }}">
         {% if page.logo %}
-        <img alt="{{ page.title }} logo" src="{{ site.baseurl }}{{ page.logo }}" width="128" height="128">
+        <img alt="{{ page.title }} logo" src="{{ page.logo | relative_url }}" width="128" height="128">
         {% elsif site.logo %}
-        <img alt="{{ site.title }} logo" src="{{ site.baseurl }}{{ site.logo }}" width="128" height="128">
+        <img alt="{{ site.title }} logo" src="{{ site.logo | relative_url }}" width="128" height="128">
         {% else %}
-        <img alt="Homebrew logo" src="{{ site.baseurl }}/assets/img/homebrew-256x256.png" width="128" height="128">
+        <img alt="Homebrew logo" src="{{ "/assets/img/homebrew-256x256.png" | relative_url }}" width="128" height="128">
         {% endif %}
         <h1><a href="{{ site.baseurl }}/">{{ site.title }}</a></h1>
         {% if t.subtitle %}


### PR DESCRIPTION
Urls for assets need to have their baseurl prepended in order to support being hosted at subpaths (ie, the default for GitHub Pages without custom domains). However, the current implementation of manually prepending the site.baseurl within the template is problematic for sub-sites that override their site.logo to reference a fully-qualified absolute URL. (Like [formulae.brew.sh does](https://github.com/Homebrew/formulae.brew.sh/blob/f7236a1d434370a62fc61fdae144b3de78fe4402/_config.yml#L50) within their _config.yml.)

This isn't currently a problem for formulae.brew.sh because it is hosted at the root of its subdomain, so its baseurl is empty. However, when a sub-site is not hosted at the root, the outcome is something like `/foo-repohttps://brew.sh/assets/img/homebrew-256x256.png`

Example output of the main site logo from the nodenv fork of formulae.brew.sh:

`src="/formulaehttps://brew.sh/assets/img/homebrew-256x256.png"`

This PR uses the jekyll filter `relativeurl`, which is purpose-built to do the baseurl prepending. Furthermore, as of jekyll 3.7.0, it intelligently _avoids_ prepending any URL that is already a fully-qualified absolute url.