### PR TITLE
Update footer content

### DIFF
--- a/_data/locales/ar.yml
+++ b/_data/locales/ar.yml
@@ -27,4 +27,4 @@ ar:
       analytics: احصائيات الحزم
     foot:
       code: تم تطوير Homebrew بواسطة <a href="https://mxcl.github.io/">Max Howell</a>.
-      page: تم تطوير هذا الموقع بواسطة <a href="https://www.exomel.com/">Rémi Prévost</a>، <a href="https://mikemcquaid.com">Mike McQuaid</a> و<a href="https://danilalo.com/">Danielle Lalonde</a><br>تمة الترجمة بواسطة <a href="https://ahmadsantarissy.com">Ahmad Santarissy</a>
+      page: تم تطوير هذا الموقع بواسطة <a href="https://exomel.com/">Rémi Prévost</a>، <a href="https://mikemcquaid.com">Mike McQuaid</a> و<a href="https://cargocollective.com/danilalo">Danielle Lalonde</a><br>تمة الترجمة بواسطة <a href="https://ahmadsantarissy.com">Ahmad Santarissy</a>

--- a/_data/locales/ar.yml
+++ b/_data/locales/ar.yml
@@ -27,4 +27,5 @@ ar:
       analytics: احصائيات الحزم
     foot:
       code: تم تطوير Homebrew بواسطة <a href="https://mxcl.github.io/">Max Howell</a>.
-      page: تم تطوير هذا الموقع بواسطة <a href="https://exomel.com/">Rémi Prévost</a>، <a href="https://mikemcquaid.com">Mike McQuaid</a> و<a href="https://cargocollective.com/danilalo">Danielle Lalonde</a><br>تمة الترجمة بواسطة <a href="https://ahmadsantarissy.com">Ahmad Santarissy</a>
+      page: تم تطوير هذا الموقع بواسطة <a href="https://exomel.com/">Rémi Prévost</a>، <a href="https://mikemcquaid.com">Mike McQuaid</a> و<a href="https://cargocollective.com/danilalo">Danielle Lalonde</a>.
+      translation: تمة الترجمة بواسطة <a href="https://ahmadsantarissy.com">Ahmad Santarissy</a>.

--- a/_data/locales/az.yml
+++ b/_data/locales/az.yml
@@ -27,4 +27,4 @@ az:
       analytics: Analytics Data
     foot:
       code: Original kodun müəllifi — <a href="https://mxcl.github.io/">Max Howell</a>.
-      page: Saytı hazırlayan — <a href="https://www.exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> and <a href="https://danilalo.com/">Danielle Lalonde</a>.
+      page: Saytı hazırlayan — <a href="https://exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> and <a href="https://cargocollective.com/danilalo">Danielle Lalonde</a>.

--- a/_data/locales/be.yml
+++ b/_data/locales/be.yml
@@ -27,4 +27,4 @@ be:
       analytics: Analytics Data
     foot:
       code: Распрацоўшчык — <a href="https://mxcl.github.io/">Max Howell</a>.
-      page: Вэб-сайт — <a href="https://www.exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> and <a href="https://danilalo.com/">Danielle Lalonde</a>.
+      page: Вэб-сайт — <a href="https://exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> and <a href="https://cargocollective.com/danilalo">Danielle Lalonde</a>.

--- a/_data/locales/bg.yml
+++ b/_data/locales/bg.yml
@@ -27,4 +27,4 @@ bg:
       analytics: Analytics Data
     foot:
       code: Разработчик — <a href="https://mxcl.github.io/">Max Howell</a>.
-      page: Сайт — <a href="https://www.exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> and <a href="https://danilalo.com/">Danielle Lalonde</a>.
+      page: Сайт — <a href="https://exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> and <a href="https://cargocollective.com/danilalo">Danielle Lalonde</a>.

--- a/_data/locales/ca.yml
+++ b/_data/locales/ca.yml
@@ -27,5 +27,5 @@ ca:
       analytics: Analytics Data
     foot:
       code: Codi original per <a href="https://mxcl.github.io/">Max Howell</a>.
-      page: Pàgina web per <a href="https://www.exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> and <a href="https://danilalo.com/">Danielle Lalonde</a>.
+      page: Pàgina web per <a href="https://exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> and <a href="https://cargocollective.com/danilalo">Danielle Lalonde</a>.
       translation: Traducció al català de <a href="https://twitter.com/msonsona">Miquel Sonsona

--- a/_data/locales/ca.yml
+++ b/_data/locales/ca.yml
@@ -28,4 +28,4 @@ ca:
     foot:
       code: Codi original per <a href="https://mxcl.github.io/">Max Howell</a>.
       page: Pàgina web per <a href="https://exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> and <a href="https://cargocollective.com/danilalo">Danielle Lalonde</a>.
-      translation: Traducció al català de <a href="https://twitter.com/msonsona">Miquel Sonsona
+      translation: Traducció al català de <a href="https://twitter.com/msonsona">Miquel Sonsona</a>.

--- a/_data/locales/cs.yml
+++ b/_data/locales/cs.yml
@@ -27,4 +27,4 @@ cs:
       analytics: Analytická data
     foot:
       code: Homebrew byl vytvořen <a href="https://mxcl.github.io/">Maxem Howellem</a>.
-      page: Web vytvořili <a href="https://www.exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> a <a href="https://danilalo.com/">Danielle Lalonde</a>.
+      page: Web vytvořili <a href="https://exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> a <a href="https://cargocollective.com/danilalo">Danielle Lalonde</a>.

--- a/_data/locales/da.yml
+++ b/_data/locales/da.yml
@@ -29,4 +29,4 @@ da:
       analytics: Analytics Data
     foot:
       code: Originalkode af <a href="https://mxcl.github.io/">Max Howell</a>.
-      page: Hjemmeside af <a href="https://www.exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> and <a href="https://danilalo.com/">Danielle Lalonde</a>.
+      page: Hjemmeside af <a href="https://exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> and <a href="https://cargocollective.com/danilalo">Danielle Lalonde</a>.

--- a/_data/locales/de.yml
+++ b/_data/locales/de.yml
@@ -27,4 +27,4 @@ de:
       analytics: Analysedaten
     foot:
       code: Originalcode von <a href="https://mxcl.github.io/">Max Howell</a>.
-      page: Webseite von <a href="https://www.exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> und <a href="https://danilalo.com/">Danielle Lalonde</a>.
+      page: Webseite von <a href="https://exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> und <a href="https://cargocollective.com/danilalo">Danielle Lalonde</a>.

--- a/_data/locales/el.yml
+++ b/_data/locales/el.yml
@@ -27,4 +27,4 @@ el:
       analytics: Αναλυτικά Δεδομένα
     foot:
       code: Το Homebrew δημιουργήθηκε από τον <a href="https://mxcl.github.io/">Max Howell</a>.
-      page: Ο ιστότοπος δημιουργήθηκε από τους <a href="https://www.exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> και <a href="https://danilalo.com/">Danielle Lalonde</a>.
+      page: Ο ιστότοπος δημιουργήθηκε από τους <a href="https://exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> και <a href="https://cargocollective.com/danilalo">Danielle Lalonde</a>.

--- a/_data/locales/en.yml
+++ b/_data/locales/en.yml
@@ -27,4 +27,4 @@ en:
       analytics: Analytics Data
     foot:
       code: Homebrew was created by <a href="https://mxcl.github.io/">Max Howell</a>.
-      page: Website by <a href="https://www.exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> and <a href="https://danilalo.com/">Danielle Lalonde</a>.
+      page: Website by <a href="https://exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> and <a href="https://cargocollective.com/danilalo">Danielle Lalonde</a>.

--- a/_data/locales/es.yml
+++ b/_data/locales/es.yml
@@ -27,5 +27,5 @@ es:
       analytics: Analíticas
     foot:
       code: Código original de <a href="https://mxcl.github.io/">Max Howell</a>.
-      page: Sitio web de <a href="https://www.exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> y <a href="https://danilalo.com/">Danielle Lalonde</a>.
+      page: Sitio web de <a href="https://exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> y <a href="https://cargocollective.com/danilalo">Danielle Lalonde</a>.
       translation: Traducción al castellano por Andrés Catalán y <a href="https://github.com/mrtnpwn">Martín Aguilar</a>.

--- a/_data/locales/fa.yml
+++ b/_data/locales/fa.yml
@@ -27,4 +27,4 @@ fa:
       analytics: Analytics Data
     foot:
       code: <a href="https://mxcl.github.io/">Max Howell</a>  برنامه‌نویس اصلی.
-      page: <a href="https://www.exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> and <a href="https://danilalo.com/">Danielle Lalonde</a>  طراح سایت
+      page: <a href="https://exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> and <a href="https://cargocollective.com/danilalo">Danielle Lalonde</a>  طراح سایت

--- a/_data/locales/fi.yml
+++ b/_data/locales/fi.yml
@@ -27,4 +27,4 @@ fi:
       analytics: Analytics Data
     foot:
       code: Alkuperäisen koodin on tehnyt <a href="https://mxcl.github.io/">Max Howell</a>.
-      page: Verkkosivun ovat tehneet <a href="https://www.exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> ja <a href="https://danilalo.com/">Danielle Lalonde</a>.
+      page: Verkkosivun ovat tehneet <a href="https://exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> ja <a href="https://cargocollective.com/danilalo">Danielle Lalonde</a>.

--- a/_data/locales/fr.yml
+++ b/_data/locales/fr.yml
@@ -27,5 +27,5 @@ fr:
       analytics: Analytics Data
     foot:
       code: Code original par <a href="https://mxcl.github.io/">Max Howell</a>.
-      page: Site web par <a href="https://www.exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> and <a href="https://danilalo.com/">Danielle Lalonde</a>.
+      page: Site web par <a href="https://exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> and <a href="https://cargocollective.com/danilalo">Danielle Lalonde</a>.
       translation: Traduction française par <a href="https://twitter.com/louim">Louis-Michel Couture</a>.

--- a/_data/locales/gl.yml
+++ b/_data/locales/gl.yml
@@ -27,5 +27,5 @@ gl:
       analytics: Analíticas dos Datos
     foot:
       code: Homebrew foi creado por <a href="https://mxcl.github.io/">Max Howell</a>.
-      page: Páxina web de <a href="https://www.exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> e <a href="https://danilalo.com/">Danielle Lalonde</a>.
+      page: Páxina web de <a href="https://exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> e <a href="https://cargocollective.com/danilalo">Danielle Lalonde</a>.
       translation: Tradución ao galego de Adolfo Núñez.

--- a/_data/locales/he.yml
+++ b/_data/locales/he.yml
@@ -27,4 +27,4 @@ he:
       analytics: Analytics Data
     foot:
       code: הקוד נכתב במקור על ידי <a href="https://mxcl.github.io/">Max Howell</a>.
-      page: האתר נבנה על ידי <a href="https://www.exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> ו-<a href="https://danilalo.com/">Danielle Lalonde</a>.
+      page: האתר נבנה על ידי <a href="https://exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> ו-<a href="https://cargocollective.com/danilalo">Danielle Lalonde</a>.

--- a/_data/locales/it.yml
+++ b/_data/locales/it.yml
@@ -28,4 +28,4 @@ it:
     foot:
       code: Versione originale creata da <a href="https://mxcl.github.io/">Max Howell</a>.
       page: Sito di <a href="https://exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> and <a href="https://cargocollective.com/danilalo">Danielle Lalonde</a>.
-      translation: Traduzione di Mattia Asti
+      translation: Traduzione di Mattia Asti.

--- a/_data/locales/it.yml
+++ b/_data/locales/it.yml
@@ -27,5 +27,5 @@ it:
       analytics: Analytics Data
     foot:
       code: Versione originale creata da <a href="https://mxcl.github.io/">Max Howell</a>.
-      page: Sito di <a href="https://www.exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> and <a href="https://danilalo.com/">Danielle Lalonde</a>.
+      page: Sito di <a href="https://exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> and <a href="https://cargocollective.com/danilalo">Danielle Lalonde</a>.
       translation: Traduzione di Mattia Asti

--- a/_data/locales/ja.yml
+++ b/_data/locales/ja.yml
@@ -26,6 +26,6 @@ ja:
       formulae: Homebrewパッケージ
       analytics: 分析データ
     foot:
-      code: Homebrewは<a href="https://mxcl.github.io">Max Howell</a>によって開発されました。
-      page: ウェブサイト作成：<a href="https://www.exomel.com">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a>, <a href="https://danilalo.com">Danielle Lalonde</a>.
+      code: Homebrewは<a href="https://mxcl.github.io/">Max Howell</a>によって開発されました。
+      page: ウェブサイト作成：<a href="https://exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a>, <a href="https://cargocollective.com/danilalo">Danielle Lalonde</a>.
       translation: 翻訳：<a href="https://www.okuryu.com">Ryuichi Okumura</a>.

--- a/_data/locales/ko.yml
+++ b/_data/locales/ko.yml
@@ -27,5 +27,5 @@ ko:
       analytics: 통계 정보
     foot:
       code: Homebrew는 <a href="https://mxcl.github.io/">Max Howell</a>에 의해 만들어졌습니다.
-      page: 웹사이트 <a href="https://www.exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> and <a href="https://danilalo.com/">Danielle Lalonde</a>.
+      page: 웹사이트 <a href="https://exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> and <a href="https://cargocollective.com/danilalo">Danielle Lalonde</a>.
       translation: 번역 <a href="https://rkjun.wordpress.com/">Juntai Park</a>, <a href="https://github.com/ghmlee">Graham Lee</a>, ChangJoon and <a href="https://github.com/PricelessCode">Matt Lee</a>.

--- a/_data/locales/nb.yml
+++ b/_data/locales/nb.yml
@@ -27,4 +27,4 @@ nb:
       analytics: Analytics Data
     foot:
       code: Originalkode av <a href="https://mxcl.github.io/">Max Howell</a>.
-      page: Nettside av <a href="https://www.exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> and <a href="https://danilalo.com/">Danielle Lalonde</a>.
+      page: Nettside av <a href="https://exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> and <a href="https://cargocollective.com/danilalo">Danielle Lalonde</a>.

--- a/_data/locales/nl.yml
+++ b/_data/locales/nl.yml
@@ -27,4 +27,4 @@ nl:
       analytics: Analytics Data
     foot:
       code: Originele code door <a href="https://mxcl.github.io/">Max Howell</a>.
-      page: Website door <a href="https://www.exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> en <a href="https://danilalo.com/">Danielle Lalonde</a>.
+      page: Website door <a href="https://exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> en <a href="https://cargocollective.com/danilalo">Danielle Lalonde</a>.

--- a/_data/locales/nn.yml
+++ b/_data/locales/nn.yml
@@ -27,4 +27,4 @@ nn:
       analytics: Analytics Data
     foot:
       code: Homebrew vart laga av <a href="https://mxcl.github.io/">Max Howell</a>.
-      page: Nettside av <a href="https://www.exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> og <a href="https://danilalo.com/">Danielle Lalonde</a>.
+      page: Nettside av <a href="https://exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> og <a href="https://cargocollective.com/danilalo">Danielle Lalonde</a>.

--- a/_data/locales/pl.yml
+++ b/_data/locales/pl.yml
@@ -27,4 +27,4 @@ pl:
       analytics: Dane analityczne
     foot:
       code: Oryginalny kod autorstwa <a href="https://mxcl.github.io/">Max Howell</a>.
-      page: Strona autorstwa <a href="https://www.exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> and <a href="https://danilalo.com/">Danielle Lalonde</a>.
+      page: Strona autorstwa <a href="https://exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> and <a href="https://cargocollective.com/danilalo">Danielle Lalonde</a>.

--- a/_data/locales/pt-br.yml
+++ b/_data/locales/pt-br.yml
@@ -26,5 +26,5 @@ pt-br:
       analytics: Analytics Data
     foot:
       code: Código original por <a href="https://mxcl.github.io/">Max Howell</a>.
-      page: Website por <a href="https://www.exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> and <a href="https://danilalo.com/">Danielle Lalonde</a>.
+      page: Website por <a href="https://exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> and <a href="https://cargocollective.com/danilalo">Danielle Lalonde</a>.
       translation: Traduzido por <a href="https://github.com/jairhenrique">Jair Henrique</a>.

--- a/_data/locales/ro.yml
+++ b/_data/locales/ro.yml
@@ -27,4 +27,4 @@ ro:
       analytics: Analytics Data
     foot:
       code: Programator <a href="https://mxcl.github.io/">Max Howell</a>.
-      page: Autor Website <a href="https://www.exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> and <a href="https://danilalo.com/">Danielle Lalonde</a>.
+      page: Autor Website <a href="https://exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> and <a href="https://cargocollective.com/danilalo">Danielle Lalonde</a>.

--- a/_data/locales/ru.yml
+++ b/_data/locales/ru.yml
@@ -27,4 +27,4 @@ ru:
       analytics: Статистика
     foot:
       code: Разработчик Homebrew — <a href="https://mxcl.github.io/">Max Howell</a>.
-      page: Сайт — <a href="https://www.exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> и <a href="https://danilalo.com/">Danielle Lalonde</a>.
+      page: Сайт — <a href="https://exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> и <a href="https://cargocollective.com/danilalo">Danielle Lalonde</a>.

--- a/_data/locales/sr.yml
+++ b/_data/locales/sr.yml
@@ -27,4 +27,4 @@ sr:
       analytics: Analytics Data
     foot:
       code: Оригинални код - <a href="https://mxcl.github.io/">Max Howell</a>.
-      page: Сајт - <a href="https://www.exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> и <a href="https://danilalo.com/">Danielle Lalonde</a>.
+      page: Сајт - <a href="https://exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> и <a href="https://cargocollective.com/danilalo">Danielle Lalonde</a>.

--- a/_data/locales/sv.yml
+++ b/_data/locales/sv.yml
@@ -27,4 +27,4 @@ sv:
       analytics: Data Analys och Statistik
     foot:
       code: Homebrew skapades av <a href="https://mxcl.github.io/">Max Howell</a>.
-      page: Hemsidan underhålls av <a href="https://www.exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> och <a href="https://danilalo.com/">Danielle Lalonde</a>.
+      page: Hemsidan underhålls av <a href="https://exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> och <a href="https://cargocollective.com/danilalo">Danielle Lalonde</a>.

--- a/_data/locales/th.yml
+++ b/_data/locales/th.yml
@@ -27,4 +27,4 @@ th:
       analytics: Analytics Data
     foot:
       code: Homebrew was created by <a href="https://mxcl.github.io/">Max Howell</a>.
-      page: Website by <a href="https://www.exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> and <a href="https://danilalo.com/">Danielle Lalonde</a>.
+      page: Website by <a href="https://exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> and <a href="https://cargocollective.com/danilalo">Danielle Lalonde</a>.

--- a/_data/locales/tr.yml
+++ b/_data/locales/tr.yml
@@ -27,4 +27,4 @@ tr:
       analytics: Analytics Verileri
     foot:
       code: Özgün kodu yazan <a href="https://mxcl.github.io/">Max HowelL</a>.
-      page: Siteyi hazırlayanlar <a href="https://www.exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a>, <a href="https://danilalo.com/">Danielle Lalonde</a> ve <a href="https://sadikkuzu.com">Sadık Kuzu</a>.
+      page: Siteyi hazırlayanlar <a href="https://exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a>, <a href="https://cargocollective.com/danilalo">Danielle Lalonde</a> ve <a href="https://sadikkuzu.com">Sadık Kuzu</a>.

--- a/_data/locales/tr.yml
+++ b/_data/locales/tr.yml
@@ -27,4 +27,5 @@ tr:
       analytics: Analytics Verileri
     foot:
       code: Özgün kodu yazan <a href="https://mxcl.github.io/">Max HowelL</a>.
-      page: Siteyi hazırlayanlar <a href="https://exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a>, <a href="https://cargocollective.com/danilalo">Danielle Lalonde</a> ve <a href="https://sadikkuzu.com">Sadık Kuzu</a>.
+      page: Siteyi hazırlayanlar <a href="https://exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a>, <a href="https://danilalo.com/">Danielle Lalonde</a>.
+      translation: Tercüme eden <a href="https://sadikkuzu.com">Sadık Kuzu</a>.

--- a/_data/locales/uk.yml
+++ b/_data/locales/uk.yml
@@ -27,4 +27,4 @@ uk:
       analytics: Дані для аналізу
     foot:
       code: Первинна розробка — <a href="https://mxcl.github.io/">Max Howell</a>.
-      page: Сайт — <a href="https://www.exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> та <a href="https://danilalo.com/">Danielle Lalonde</a>.
+      page: Сайт — <a href="https://exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> та <a href="https://cargocollective.com/danilalo">Danielle Lalonde</a>.

--- a/_data/locales/vi.yml
+++ b/_data/locales/vi.yml
@@ -27,4 +27,4 @@ vi:
       analytics: Analytics Data
     foot:
       code: Mã gốc bởi <a href="https://mxcl.github.io/">Max Howell</a>.
-      page: Website bởi <a href="https://www.exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> and <a href="https://danilalo.com/">Danielle Lalonde</a>.
+      page: Website bởi <a href="https://exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> and <a href="https://cargocollective.com/danilalo">Danielle Lalonde</a>.

--- a/_data/locales/zh-cn.yml
+++ b/_data/locales/zh-cn.yml
@@ -26,4 +26,4 @@ zh-cn:
       analytics: Analytics Data
     foot:
       code: Homebrew 创建者：<a href="https://mxcl.github.io/">Max Howell</a>。
-      page: 网站搭建者：<a href="https://www.exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> 和 <a href="https://danilalo.com/">Danielle Lalonde</a>。
+      page: 网站搭建者：<a href="https://exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> 和 <a href="https://cargocollective.com/danilalo">Danielle Lalonde</a>。

--- a/_data/locales/zh-tw.yml
+++ b/_data/locales/zh-tw.yml
@@ -26,4 +26,4 @@ zh-tw:
       analytics: Analytics Data
     foot:
       code: Homebrew was created by <a href="https://mxcl.github.io/">Max Howell</a>.
-      page: Website by <a href="https://www.exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> and <a href="https://danilalo.com/">Danielle Lalonde</a>.
+      page: Website by <a href="https://exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> and <a href="https://cargocollective.com/danilalo">Danielle Lalonde</a>.

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -202,7 +202,7 @@ Editing /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/foo.rb
 
     <li>
       <div class="group row credits">
-        <p>{{ t.pagecontent.foot.code }} {{ t.pagecontent.foot.page }} {{ t.pagecontent.foot.translation }}</p>
+        <p>{{ t.pagecontent.foot.code }} {{ t.pagecontent.foot.page }}<br>{{ t.pagecontent.foot.translation }}</p>
       </div>
     </li>
   </ul>


### PR DESCRIPTION
- drop `www` from `exomel.com`
- `danilalo.com` is no longer live, but `cargocollective.com/danilalo` is
- relocate translator names to their own line