### PR TITLE
Localization: Tiny adjustment of the German localization

### DIFF
--- a/_data/locales/de.yml
+++ b/_data/locales/de.yml
@@ -4,7 +4,7 @@ de:
   pagecontent:
     search: Search
     question: Was macht Homebrew?
-    what: Homebrew installiert <a href="https://formulae.brew.sh/formula/" title="Liste der Homebrew-Pakete">Zeug, das du brauchst</a>, die Apple aber nicht mitliefert.
+    what: Homebrew installiert <a href="https://formulae.brew.sh/formula/" title="Liste der Homebrew-Pakete">Zeug, das du brauchst</a>, das Apple aber nicht mitliefert.
     how: Homebrew installiert Pakete in ihrem eigenen Verzeichnis und erstellt Symlinks zu ihren Dateien in <code>/usr/local</code>.
     prefix: Homebrew installiert keine Dateien außerhalb seines Pfades und du kannst den Ort einer Homebrew-Installation frei wählen.
     createpackages: Eigene Homebrew-Pakete zu erzeugen, ist kinderleicht.


### PR DESCRIPTION
In c3ef229ce9ffa5e1d448427ad8424ba16799eb65 the term "Sachen" was replaced with "Zeug". 
Unfortunately, the article "die" still refers to the old term.