### PR TITLE
Use pipe in install instructions

### DIFF
--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -8,7 +8,7 @@ layout: base
       <div class="group row">
         <h2 id="install">{{ t.pagecontent.install.install }}</h2>
         <br>
-        <pre style='clear:both;text-align:center;margin-bottom:0.9em'><code id='selectable' onclick="selectText(this)">/bin/bash -c &quot;$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)&quot;</code></pre>
+        <pre style='clear:both;text-align:center;margin-bottom:0.9em'><code id='selectable' onclick="selectText(this)">curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh | /bin/bash</code></pre>
 
         <div class="col-1">
           <p>{{ t.pagecontent.install.paste }}</p>


### PR DESCRIPTION
The current brew install instructions [don't work if you are already running fish](https://github.com/fish-shell/fish-shell/issues/7178) (though, as most brew+fish users have installed fish using Homebrew, it comes up pretty rarely).

Changing the instructions to use a pipe improves portability to non-POSIX shells such as fish, elvish, xonsh, and even tcsh.

However! I understand that there are [potential concerns with regard to trust in the server](https://unix.stackexchange.com/a/339276/78890) with the pipe method, and possibly [issues if the connection dies mid-stream - see non-security concerns](https://sandstorm.io/news/2015-09-24-is-curl-bash-insecure-pgp-verified-install) which might require further thought.