### PR TITLE
Add style for diagrams

### DIFF
--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -589,6 +589,16 @@ span .amp {
   }
 }
 
+/* Diagrams */
+img[src$=".drawio.svg"] {
+  background-color: white;
+  margin-bottom: 20px;
+  padding: 5%;
+  width: 90%;
+  filter: invert(80%) sepia(60%);
+  -webkit-filter: invert(80%) sepia(60%);
+}
+
 /* Main dropdown wrapper */
 div .algolia-autocomplete {
   .ds-dropdown-menu::before,


### PR DESCRIPTION
This is a companion PR to https://github.com/Homebrew/brew/pull/8627.

<img width="768" alt="grafik" src="https://user-images.githubusercontent.com/1239874/92315147-2cb61800-efe2-11ea-8f84-fe81c2ed2216.png">

A few notes on the CSS:

- `background-color: white` is necessary because draw.&#8203;io uses that colour to create negative space (e. g. around labels) so the background needs to match.

- The `filter` and `-webkit-filter` properties are a workaround. They’re needed because browsers don’t allow styling across document boundaries (which an embedded `img` always constitutes).

- The filters are applied *after* setting the background colour, which is convenient because then the background colour still matches the negative space inside the SVG.
