### PR TITLE
Make dollar sign inside `.copyable` segments unselectable

### DIFF
--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -9,7 +9,7 @@ layout: base
         <h2 id="install">{{ t.pagecontent.install.install }}</h2>
         <br>
         <div class="copyable">
-          {% highlight bash %} $ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)" {% endhighlight %}
+          {%- highlight bash -%} /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)" {%- endhighlight -%}
         </div>
         <br>
         <br>

--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -229,6 +229,12 @@ div .highlight {
       @include border-side-radius("right", 0);
       margin: 0;
     }
+
+    code::before {
+      @extend .nv;
+      display: inline;
+      content: '$ ';
+    }
   }
 
   button {


### PR DESCRIPTION
Push dollar sign inside `::before` pseudoelement so double-clicking on command creates text selection without it.

### Before

![image](https://user-images.githubusercontent.com/1170440/98454079-bdcf7980-2160-11eb-8274-77b30d03f291.png)

### After

![image](https://user-images.githubusercontent.com/1170440/98454068-b019f400-2160-11eb-8e2d-f44487dbf17f.png)