### PR TITLE
Various improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
+.DS_Store
 .bundle/
 _site/
 bin/
 vendor/
 .jekyll-metadata
+.sass-cache/

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ the index is at `_layouts/index.html`.
 
 If you want to add a new translation, follow these steps:
 
-1. Copy `index.html` to `index_{langcode}.html`
-2. Copy `_data/locales/en.yml` to `_data/locales/{langcode}.yml`
-3. Change the values of the English strings to the translated, new language strings.
+1. Copy `index.html` to `index_{langcode}.html` and update its `lang` value.
+2. Copy `_data/locales/en.yml` to `_data/locales/{langcode}.yml` and update its initial language code.
+3. Change the values of the English strings to the new, translated language strings.
 
 You can see the translated webpage by running `jekyll serve` and opening
-<http://localhost:4000/>
+<http://localhost:4000/>.
 
 ### Transifex
 

--- a/_data/locales/lb.yml
+++ b/_data/locales/lb.yml
@@ -1,4 +1,4 @@
-en:
+lb:
   locale_name: Lëtzebuergesch
   subtitle: Den feelenden Packungsverwalter fir macOS (oder dengem Linux system)
   pagecontent:

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -138,6 +138,7 @@ algolia:
           {{ layout.algolia | jsonify }}
         ));
         document.querySelector("#search-bar").focus();
+        document.querySelector("#search-bar").value = new URLSearchParams(window.location.search).get('search');
       };
 
       function setupCopyables() {

--- a/_posts/2020-11-18-homebrew-tap-with-bottles-uploaded-to-github-releases.md
+++ b/_posts/2020-11-18-homebrew-tap-with-bottles-uploaded-to-github-releases.md
@@ -3,13 +3,11 @@ title: Homebrew tap with bottles uploaded to GitHub Releases
 author: dawidd6
 ---
 
-## Introduction
+Since the [Homebrew 2.5.2 release](https://github.com/Homebrew/brew/releases/tag/2.5.2), you can upload bottles (binary packages) to GitHub Releases, in addition to the previous standard - Bintray. Support was added to `Homebrew/brew` in this [PR](https://github.com/Homebrew/brew/pull/8410) on 2020-09-15, and a [companion PR](https://github.com/Homebrew/homebrew-test-bot/pull/486) to `Homebrew/homebrew-test-bot` added support for setting the base download URL of bottles to point to a specific release on GitHub.
 
-Since the [Homebrew 2.5.2 release](https://github.com/Homebrew/brew/releases/tag/2.5.2), you can upload bottles (binary packages) to GitHub Releases, in addition to the previous standard - Bintray. The [PR](https://github.com/Homebrew/brew/pull/8410) to `Homebrew/brew` was merged on 15 September. A [companion PR](https://github.com/Homebrew/homebrew-test-bot/pull/486) to `Homebrew/homebrew-test-bot` added support for setting the base download URL of bottles pointing to specific release on GitHub.
+### Creating the tap
 
-## Creating the tap
-
-First, go to GitHub and create an empty repository named with `homebrew-` prefix, for example: `USER/homebrew-tap`.
+First, go to GitHub and create an empty repository named with the `homebrew-` prefix, for example: `USER/homebrew-tap`.
 
 ![github-repo](/assets/img/blog/homebrew-tap-github-releases/github-repo.png)
 
@@ -19,7 +17,7 @@ Then locally run:
 brew tap-new USER/REPO
 ```
 
-changing `USER/REPO` to the full name of repository that you just created on GitHub. You can omit the `homebrew-` prefix and specify the `--branch` flag, if your default branch should be named differently than `main`.
+changing `USER/REPO` to the full name of the repository that you just created on GitHub. You can omit the `homebrew-` prefix and specify the `--branch` flag if your default branch should be named differently than `main`.
 
 ![brew-tap-new](/assets/img/blog/homebrew-tap-github-releases/brew-tap-new.png)
 
@@ -33,7 +31,7 @@ cd $(brew --repository USER/REPO)
 
 Now you can list all files in this tap to see what is created by default.
 
-Add the repository that you created on GitHub as `origin` remote and push newly created files:
+Add the repository that you created on GitHub as the `origin` remote and push newly created files:
 
 ```sh
 git remote add origin https://github.com/USER/REPO
@@ -42,13 +40,16 @@ git push --set-upstream origin main
 
 ![git-push](/assets/img/blog/homebrew-tap-github-releases/git-push.png)
 
-I won't go into too many details on how the workflows look, as they are subject to change at any time. For now, there are 2 workflow files created by default. One is run on `pull_request` event, so every push to a PR's branch triggers the workflow, tests changes made to formulae, builds bottles for those formulae and uploads them to GitHub Actions as artifacts. The second workflow is run when a pull request is labelled and it is responsible for bottle uploading and publishing.
+I won't go into too many details on how the workflows look, as they are subject to change at any time. For now, there are 2 workflow files created by default.
 
-## Creating first formula in tap
+- One is run on each `pull_request` event, so every push to a PR's branch triggers the workflow, which tests changes made to formulae, builds bottles for those formulae and uploads them to GitHub Actions as artifacts.
+- The second workflow, run when a pull request is labelled, is responsible for bottle uploading and publishing.
 
-It's time we add a new formula to our tap, shall we?
+### Creating the first formula in the tap
 
-All formulae should go to `Formula` directory. Let's suppose we want to create a formula of this little Go program named [`gothanks`](https://github.com/psampaz/gothanks). Run locally:
+It's time we add a new formula to our tap; shall we?
+
+All formulae should go in the `Formula` directory. Let's suppose we want to create a formula for this little Go program named [`gothanks`](https://github.com/psampaz/gothanks). Run locally:
 
 ```sh
 brew create --tap=USER/REPO --go https://github.com/psampaz/gothanks/archive/v0.3.0.tar.gz
@@ -98,18 +99,18 @@ git push --set-upstream origin gothanks
 
 ![git-branch](/assets/img/blog/homebrew-tap-github-releases/git-branch.png)
 
-But to trigger the workflows, we need to create a pull request for just pushed branch. I'm using `hub` utility for this operation, but you can use the newer GitHub CLI `gh` or just click your way through in GitHub UI.
+But to trigger the workflows, we need to create a pull request from our recently-pushed branch. I'm using the `hub` utility for this operation, but you can use the newer GitHub CLI tool `gh` or just click your way through in GitHub's UI.
 
 ![github-pr](/assets/img/blog/homebrew-tap-github-releases/github-pr.png)
 
-## Uploading built bottles
+### Uploading built bottles
 
-Wait until the checks become green in PR. Then label your pull request with `pr-pull` label (this is the default label for which uploading workflow will trigger, you can easily change that in workflow file). A new `brew pr-pull` workflow will be fired up and after a couple of minutes you should observe the PR closed, bottles uploaded and commits pushed to the main branch of your repository.
+Wait until the pull request's checks become green. Then label your pull request with the `pr-pull` label (this is the default label that will trigger the uploading workflow; you can easily change this in workflow file). A new `brew pr-pull` workflow will be fired up and after a couple of minutes you should observe the PR closed, bottles uploaded and commits pushed to the main branch of your repository.
 
 ![github-pr-closed](/assets/img/blog/homebrew-tap-github-releases/github-pr-closed.png)
 ![github-release](/assets/img/blog/homebrew-tap-github-releases/github-release.png)
 ![github-commits](/assets/img/blog/homebrew-tap-github-releases/github-commits.png)
 
-## Summary
+### Summary
 
-With current tooling it is easier than ever to create your own Homebrew tap with bottles. Gone are the days when you had to create a Bintray account and fiddle around with custom CI configs. Now you can run a bunch of commands and get a tap up and running in minutes, with only a GitHub account!
+With current tooling it's now easier than ever to create your own Homebrew tap with bottles. Gone are the days when you had to create a Bintray account and fiddle around with custom CI configs. Now you can run a bunch of commands and get a tap up and running in minutes, with only a GitHub account!

--- a/analytics-linux/build-error/index.html
+++ b/analytics-linux/build-error/index.html
@@ -1,0 +1,4 @@
+---
+title: Homebrew Analytics Linux Build Error Events
+redirect_to: https://formulae.brew.sh/analytics-linux/build-error/365d/
+---

--- a/analytics-linux/index.html
+++ b/analytics-linux/index.html
@@ -1,0 +1,4 @@
+---
+title: Homebrew Analytics Linux Data
+redirect_to: https://formulae.brew.sh/analytics/#linux
+---

--- a/analytics-linux/install-on-request/index.html
+++ b/analytics-linux/install-on-request/index.html
@@ -1,0 +1,4 @@
+---
+title: Homebrew Analytics Linux Install On Request Events
+redirect_to: https://formulae.brew.sh/analytics-linux/install-on-request/365d/
+---

--- a/analytics-linux/install/index.html
+++ b/analytics-linux/install/index.html
@@ -1,0 +1,4 @@
+---
+title: Homebrew Analytics Linux Install Events
+redirect_to: https://formulae.brew.sh/analytics-linux/install/365d/
+---

--- a/analytics/cask-install/index.html
+++ b/analytics/cask-install/index.html
@@ -1,0 +1,4 @@
+---
+title: Homebrew Analytics Cask Install Events
+redirect_to: https://formulae.brew.sh/analytics/cask-install/365d/
+---

--- a/index_nb.html
+++ b/index_nb.html
@@ -1,4 +1,4 @@
 ---
 layout: index
-lang: "nb"
+lang: nb
 ---

--- a/index_nn.html
+++ b/index_nn.html
@@ -1,4 +1,4 @@
 ---
 layout: index
-lang: "nn"
+lang: nn
 ---


### PR DESCRIPTION
- fix display of `lb` translation and improve translation instructions
- update `.gitignore` to [match other repos](https://github.com/Homebrew/formulae.brew.sh/pull/332)
- add redirects for cask-install and Linux analytics URLs
- fix up display of the [latest blog post](https://brew.sh/2020/11/18/homebrew-tap-with-bottles-uploaded-to-github-releases/)
- allow a "search" query parameter to set the value of the search bar for DuckDuckGo !bang integration, as suggested in https://github.com/Homebrew/formulae.brew.sh/issues/234, e.g. https://brew.sh/?search=firefox