### PR TITLE
Don't autofocus search bar if URL contains anchor link

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -137,7 +137,7 @@ algolia:
           { algoliaOptions: { facetFilters: ['lang: ' + lang, 'site: ' + site] } },
           {{ layout.algolia | jsonify }}
         ));
-        document.querySelector("#search-bar").focus();
+        window.location.hash || document.querySelector("#search-bar").focus();
         document.querySelector("#search-bar").value = new URLSearchParams(window.location.search).get('search');
       };
 


### PR DESCRIPTION
Otherwise the page scrolls back up from the anchor to the search bar on load.