### PR TITLE
2.7.0: fix some mistakes

### DIFF
--- a/_posts/2020-12-21-homebrew-2.7.0.md
+++ b/_posts/2020-12-21-homebrew-2.7.0.md
@@ -2,7 +2,7 @@
 title: 2.7.0
 author: MikeMcQuaid
 ---
-Today I'd like to announce Homebrew 2.7.0. The most significant changes since 2.5.0 are ... and API deprecations.
+Today I'd like to announce Homebrew 2.7.0. The most significant changes since 2.6.0 are API deprecations.
 
 Changes and deprecations since 2.6.0:
 
@@ -14,6 +14,7 @@ Changes and deprecations since 2.6.0:
 - [`brew update` refuses to update shallow homebrew-core/cask clones (on request from GitHub).](https://github.com/Homebrew/brew/pull/9383)
 - [The `HOMEBREW_CLEANUP_PERIODIC_FULL_DAYS` environment variable allows customisation of how often a full `brew cleanup` is run.](https://github.com/Homebrew/brew/pull/9477)
 - [Installing formulae missing bottles from the homebrew-core or linuxbrew-core requires specifying `--build-from-source`.](https://github.com/Homebrew/brew/pull/9518)
+- [`brew livecheck` now supports casks.](https://github.com/Homebrew/brew/pull/8578)
 
 Finally:
 


### PR DESCRIPTION
Some fixes for the 2.7.0 blog post.

I also added a reference to `brew livecheck` supporting casks as this is a bigger change since 2.6.0.
