### PR TITLE
Add redirect to latest release

### DIFF
--- a/.github/actions/check-redirects.rb
+++ b/.github/actions/check-redirects.rb
@@ -1,0 +1,25 @@
+require 'pathname'
+
+post_folder = '_posts'
+release_post_regex = /^\d{4}-\d{2}-\d{2}-homebrew-(\d+\.\d+\.\d+)\.md$/
+
+files_with_bad_redirects = []
+
+Pathname.glob("#{post_folder}/*").each do |post_file|
+  file_name = post_file.basename
+  match = file_name.to_s.match release_post_regex
+  next if match.nil?
+
+  if post_file.readlines.grep(%r{^redirect_from: /blog/#{match[1]}/$}).none?
+    files_with_bad_redirects << file_name
+  end
+end
+
+exit if files_with_bad_redirects.empty?
+
+puts <<~MESSAGE
+  Error: the following release posts do not contain a redirect from `/blog/<version>`:
+    #{files_with_bad_redirects.join("\n  ")}
+MESSAGE
+
+exit 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,4 +34,13 @@ jobs:
       - name: Run Vale linting on Markdown files
         run: |
           brew install vale
-          vale --config=$(brew --repo)/.vale.ini _posts/
+          vale --config=$(brew --repo)/.vale.ini _posts/  
+  
+  check-redirects:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@master
+
+      - name: Check release notes redirect
+        run: ruby ./.github/actions/check-redirects.rb

--- a/_posts/2016-09-21-homebrew-1.0.0.md
+++ b/_posts/2016-09-21-homebrew-1.0.0.md
@@ -2,6 +2,7 @@
 title: 1.0.0
 author: MikeMcQuaid
 redirect_from: /2016/09/02/homebrew-1.0.0/
+redirect_from: /blog/1.0.0/
 ---
 Today I'm proud to announce Homebrew 1.0.0. In the seven years since Homebrew was created by [@mxcl](https://github.com/mxcl) our community has grown to [almost 6000 unique contributors](https://github.com/Homebrew/homebrew-core/graphs/contributors), a [wide-reaching third-party "tap" ecosystem](https://github.com/search?p=2&q=homebrew-&type=Repositories&utf8=✓) and [thousands of packages](https://github.com/Homebrew/homebrew-core/tree/master/Formula).
 

--- a/_posts/2016-11-07-homebrew-1.1.0.md
+++ b/_posts/2016-11-07-homebrew-1.1.0.md
@@ -1,6 +1,7 @@
 ---
 title: 1.1.0
 author: MikeMcQuaid
+redirect_from: /blog/1.1.0/
 ---
 Today I'd like to announce Homebrew 1.1.0. We've had a great response to Homebrew 1.0.0 and been iterating on our work there. That 1.1.0 follows 1.0.9 is a happy coincidence due to breaking changes; in the future we may have a e.g. 1.1.10.
 

--- a/_posts/2017-05-01-homebrew-1.2.0.md
+++ b/_posts/2017-05-01-homebrew-1.2.0.md
@@ -1,6 +1,7 @@
 ---
 title: 1.2.0
 author: MikeMcQuaid
+redirect_from: /blog/1.2.0/
 ---
 Today I'd like to announce Homebrew 1.2.0. The most significant change since 1.1.0 is that most Homebrew taps (package repositories) in the [Homebrew GitHub organisation](https://github.com/Homebrew) have been deprecated and the currently buildable software moved into [Homebrew/homebrew-core](https://github.com/Homebrew/homebrew-core). This will improve the quality and availability of all their software.
 

--- a/_posts/2017-07-31-homebrew-1.3.0.md
+++ b/_posts/2017-07-31-homebrew-1.3.0.md
@@ -1,6 +1,7 @@
 ---
 title: 1.3.0
 author: MikeMcQuaid
+redirect_from: /blog/1.3.0/
 ---
 Today I'd like to announce Homebrew 1.3.0. The most significant change since 1.2.0 is that `brew install python` no longer installs a `python` binary without manual `PATH` additions and instead installs a `python2` binary. This avoids overriding the system `python` binary by default when installing Python as a dependency. It also paves the way to eventually have `python` be Python 3.x.
 

--- a/_posts/2017-12-11-homebrew-1.4.0.md
+++ b/_posts/2017-12-11-homebrew-1.4.0.md
@@ -1,6 +1,7 @@
 ---
 title: 1.4.0
 author: MikeMcQuaid
+redirect_from: /blog/1.4.0/
 ---
 Today I'd like to announce Homebrew 1.4.0. The most significant change since 1.3.0 is that Homebrew filters environment variables.
 

--- a/_posts/2018-01-19-homebrew-1.5.0.md
+++ b/_posts/2018-01-19-homebrew-1.5.0.md
@@ -1,6 +1,7 @@
 ---
 title: 1.5.0
 author: MikeMcQuaid
+redirect_from: /blog/1.5.0/
 ---
 Today I'd like to announce Homebrew 1.5.0. The most significant changes since 1.4.0 are deprecations of formula APIs and some Homebrew organisation formula taps.
 

--- a/_posts/2018-04-09-homebrew-1.6.0.md
+++ b/_posts/2018-04-09-homebrew-1.6.0.md
@@ -1,6 +1,7 @@
 ---
 title: 1.6.0
 author: MikeMcQuaid
+redirect_from: /blog/1.6.0/
 ---
 Today I'd like to announce Homebrew 1.6.0. The most significant changes since 1.5.0 are `brew install python` installing Python 3, the deprecation of [Homebrew/php](https://github.com/homebrew/homebrew-php) and various formula API deprecations.
 

--- a/_posts/2018-07-15-homebrew-1.7.0.md
+++ b/_posts/2018-07-15-homebrew-1.7.0.md
@@ -1,6 +1,7 @@
 ---
 title: 1.7.0
 author: MikeMcQuaid
+redirect_from: /blog/1.7.0/
 ---
 Today I'd like to announce Homebrew 1.7.0. The most significant changes since 1.7.0 are fixes for macOS 10.14 Mojave's developer beta, [Homebrew Formulae's](https://formulae.brew.sh) JSON analytics and formulae APIs and various formula API deprecations.
 

--- a/_posts/2018-10-23-homebrew-1.8.0.md
+++ b/_posts/2018-10-23-homebrew-1.8.0.md
@@ -1,6 +1,7 @@
 ---
 title: 1.8.0
 author: MikeMcQuaid
+redirect_from: /blog/1.8.0/
 ---
 Today I'd like to announce Homebrew 1.8.0. The most significant changes since 1.7.0 are official Mojave support, linkage auto-repair on `brew upgrade`, `brew info` displaying analytics data and quarantining Cask’s downloads.
 

--- a/_posts/2019-01-09-homebrew-1.9.0.md
+++ b/_posts/2019-01-09-homebrew-1.9.0.md
@@ -1,6 +1,7 @@
 ---
 title: 1.9.0
 author: MikeMcQuaid
+redirect_from: /blog/1.9.0/
 ---
 Today I'd like to announce Homebrew 1.9.0. The most significant changes since 1.8.0 are Linux support, (optional) automatic `brew cleanup` and providing bottles (binary packages) to more Homebrew users.
 

--- a/_posts/2019-02-02-homebrew-2.0.0.md
+++ b/_posts/2019-02-02-homebrew-2.0.0.md
@@ -1,6 +1,7 @@
 ---
 title: 2.0.0
 author: MikeMcQuaid
+redirect_from: /blog/2.0.0/
 ---
 Today I'd like to announce Homebrew 2.0.0. The most significant changes since 1.9.0 are official support for Linux and Windows 10 (with Windows Subsystem for Linux), `brew cleanup` running automatically, no more options in Homebrew/homebrew-core, and removal of support for OS X Mountain Lion (10.8) and older.
 

--- a/_posts/2019-04-04-homebrew-2.1.0.md
+++ b/_posts/2019-04-04-homebrew-2.1.0.md
@@ -1,6 +1,7 @@
 ---
 title: 2.1.0
 author: MikeMcQuaid
+redirect_from: /blog/2.1.0/
 ---
 Today I'd like to announce Homebrew 2.1.0. The most significant changes since 2.0.0 are casks on <https://formulae.brew.sh>, search on Homebrew sites and better Docker support.
 

--- a/_posts/2019-11-27-homebrew-2.2.0.md
+++ b/_posts/2019-11-27-homebrew-2.2.0.md
@@ -1,6 +1,7 @@
 ---
 title: 2.2.0
 author: MikeMcQuaid
+redirect_from: /blog/2.2.0/
 ---
 Today I'd like to announce Homebrew 2.2.0. The most significant changes since 2.1.0 are macOS Catalina support, performance increases and better Homebrew on Linux ecosystem integration.
 

--- a/_posts/2020-05-29-homebrew-2.3.0.md
+++ b/_posts/2020-05-29-homebrew-2.3.0.md
@@ -1,6 +1,7 @@
 ---
 title: 2.3.0
 author: MikeMcQuaid
+redirect_from: /blog/2.3.0/
 ---
 Today I'd like to announce Homebrew 2.3.0. The most significant changes since 2.2.0 are GitHub Actions CI usage, fetching resources before installation, Docker image improvements and the deprecation of `brew install` from URLs.
 

--- a/_posts/2020-06-11-homebrew-2.4.0.md
+++ b/_posts/2020-06-11-homebrew-2.4.0.md
@@ -1,6 +1,7 @@
 ---
 title: 2.4.0
 author: MikeMcQuaid
+redirect_from: /blog/2.4.0/
 ---
 Today I'd like to announce Homebrew 2.4.0. The most significant changes since 2.3.0 are dropping macOS Mavericks support, the deprecation of `devel` versions and `brew audit` speedups.
 

--- a/_posts/2020-09-08-homebrew-2.5.0.md
+++ b/_posts/2020-09-08-homebrew-2.5.0.md
@@ -1,6 +1,7 @@
 ---
 title: 2.5.0
 author: MikeMcQuaid
+redirect_from: /blog/2.5.0/
 ---
 Today I'd like to announce Homebrew 2.5.0. The most significant changes since 2.4.0 are better `brew cask` integration, license support and API deprecations.
 

--- a/_posts/2020-12-01-homebrew-2.6.0.md
+++ b/_posts/2020-12-01-homebrew-2.6.0.md
@@ -1,6 +1,7 @@
 ---
 title: 2.6.0
 author: MikeMcQuaid
+redirect_from: /blog/2.6.0/
 ---
 Today I'd like to announce Homebrew 2.6.0. The most significant changes since 2.5.0 are macOS Big Sur support on Intel, `brew` commands replacing all `brew cask` commands, the beginnings of macOS M1/Apple Silicon/ARM support and API deprecations.
 

--- a/_posts/2020-12-21-homebrew-2.7.0.md
+++ b/_posts/2020-12-21-homebrew-2.7.0.md
@@ -1,6 +1,7 @@
 ---
 title: 2.7.0
 author: MikeMcQuaid
+redirect_from: /blog/2.7.0/
 ---
 Today I'd like to announce Homebrew 2.7.0. The most significant changes since 2.6.0 are API deprecations.
 


### PR DESCRIPTION
This PR adds a redirect from `/blog/latest-release/` to the most recent release notes post. See https://github.com/Homebrew/brew/pull/10117#discussion_r548521748.

This also adds a GitHub action to check and make sure that there is always exactly one redirect and that it points to the latest release notes post. See [this workflow run](https://github.com/Rylan12/brew.sh/pull/1/checks?check_run_id=1609430802) for an example of this workflow.

If this is merged, I think the `check-redirects` job should be made required.

CC @MikeMcQuaid 