### PR TITLE
Fix typo in 2.7.0 post

### DIFF
--- a/_posts/2020-12-21-homebrew-2.7.0.md
+++ b/_posts/2020-12-21-homebrew-2.7.0.md
@@ -9,7 +9,7 @@ Changes and deprecations since 2.6.0:
 
 - [The `prefix` DSL for bottles is deprecated. It was not actually used by the code.](https://github.com/Homebrew/brew/pull/9482)
 - [`deprecate!` and `disable!` in formulae with missing or non-ISO 8601 dates is deprecated.](https://github.com/Homebrew/brew/pull/9478)
-- [`depends_on :java`, `:x11`, `:osxfuse`, `:tuntap` are all deprecated in formulae and asks.](https://github.com/Homebrew/brew/pull/9403)
+- [`depends_on :java`, `:x11`, `:osxfuse`, `:tuntap` are all deprecated in formulae and casks.](https://github.com/Homebrew/brew/pull/9403)
 - [Additional API deprecations, disables and removals.](https://github.com/Homebrew/brew/pull/10056)
 - [GitHub basic authentication support is removed.](https://github.com/Homebrew/brew/pull/10045)
 - [`brew update` refuses to update shallow homebrew-core/cask clones (on request from GitHub).](https://github.com/Homebrew/brew/pull/9383)


### PR DESCRIPTION
I assume it should be `casks` not `asks`.