### PR TITLE
Set email input-box minlength to 6

### DIFF
--- a/_includes/newsletter.html
+++ b/_includes/newsletter.html
@@ -5,7 +5,7 @@
     <label for="newsletter-email">Subscribe to be notified about new posts</label>
   </h3>
   <p>
-    <input id="newsletter-email" type="email" name="EMAIL" value="">
+    <input id="newsletter-email" type="email" name="EMAIL" value="" minlength="6">
   </p>
 
   <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->


### PR DESCRIPTION
Currently there is no mode of validation for the email address that's added and
adding so might add increased complexity (such as regex). This commit adds a
simple minlength check to ensure that a minimum length e-mail address is
supplied -- at the very least.

Why set 6 as the minlength? An email ID has three parts: [username][@][domain].
The smallest username will be of 1 character and the smallest domain will have
a TLD of at least 2 characters and a domain name of at least 1 character plus a
period symbol. So:
username(1)+@(1)+domain(1)+period(1)+tld(2)=6
Hence a minimum length of 6 was chosen