### PR TITLE
nl: Typo on homepage

### DIFF
--- a/_data/locales/nl.yml
+++ b/_data/locales/nl.yml
@@ -17,7 +17,7 @@ nl:
     install:
       install: Installeer Homebrew
       paste: Plak het bovenstaande in Terminal.
-      what: Het installatiescript beschrijft wat het wilt doen en wacht voordat de installatie wordt uitgevoerd. Meer installatie-opties zijn <a href="https://docs.brew.sh/Installation">hier</a>.
+      what: Het installatiescript beschrijft wat het wil doen en wacht voordat de installatie wordt uitgevoerd. Meer installatie-opties zijn <a href="https://docs.brew.sh/Installation">hier</a>.
     doc:
       further: Verdere documentatie
       donate: Donate to Homebrew


### PR DESCRIPTION
Fix a wrong conjugation in one of the messages on the front page.