### PR TITLE
Make `man brew` documentation more prominent

### DIFF
--- a/_data/locales/ar.yml
+++ b/_data/locales/ar.yml
@@ -19,6 +19,7 @@ ar:
       paste: قم بلصق الأمر السابق في نافذة الأوامر الخاصة بـmacOS.
       what: يوضح النص ماذا سيفعل ثم سيتوقف قبل فعله. هناك خيارات تثبيت اضافية <a href="https://docs.brew.sh/Installation">هنا</a>.
     doc:
+      man: <code>man brew</code> documentation
       further: معلومات إضافية
       donate: تبرع لـHomebrew
       blog: مدونة Homebrew

--- a/_data/locales/az.yml
+++ b/_data/locales/az.yml
@@ -19,6 +19,7 @@ az:
       paste: Bunu Terminal-a əlavə edin.
       what: Əməliyyatı yerinə yetirməmişdən əvvəl proqram sizə əməliyyat barədə məlumat verir. Daha çox yükləmə üsulları <a href="https://docs.brew.sh/Installation">buradadır</a>.
     doc:
+      man: <code>man brew</code> documentation
       further: Əlavə Sənədlər
       donate: Donate to Homebrew
       blog: Homebrew Bloq

--- a/_data/locales/be.yml
+++ b/_data/locales/be.yml
@@ -19,6 +19,7 @@ be:
       paste: Скапіруйце і ўстаўце гэта ў тэрмінал.
       what: Перад выкананнем якога-небудзь дзеяння, скрыпт прыпыніцца і растлумачыць, што ён збіраецца зрабіць. Дадатковыя параметры ўстаноўкі можна знайсці <a href="https://docs.brew.sh/Installation">тут</a>.
     doc:
+      man: <code>man brew</code> documentation
       further: Дадатковая дакументацыя
       donate: Ахвяраваць Homebrew
       blog: Блог Homebrew

--- a/_data/locales/bg.yml
+++ b/_data/locales/bg.yml
@@ -19,6 +19,7 @@ bg:
       paste: Поставете това в терминал.
       what: Скрипта по-горе обяснява какво ще направи и паузира, преди да го извърши. Има и допълнителни опции за инсталиране <a href="https://docs.brew.sh/Installation">тук</a>.
     doc:
+      man: <code>man brew</code> documentation
       further: Допълнителна документация
       donate: Donate to Homebrew
       blog: Homebrew Blog

--- a/_data/locales/ca.yml
+++ b/_data/locales/ca.yml
@@ -19,6 +19,7 @@ ca:
       paste: Enganxa el codi a una finestra de Terminal.
       what: L’<i>script</i> explica el que fa i s’espera abans de fer-ho. Hi ha més opcions d’instal·lació <a href="https://docs.brew.sh/Installation">aquí</a>.
     doc:
+      man: <code>man brew</code> documentation
       further: Més Documentació
       donate: Donate to Homebrew
       blog: Homebrew Blog

--- a/_data/locales/cs.yml
+++ b/_data/locales/cs.yml
@@ -19,6 +19,7 @@ cs:
       paste: Tohle vložte do okna Terminálu.
       what: Script vysvětlí, co udělá, a než to udělá, pozastaví se. Další možnosti instalace naleznete <a href="https://docs.brew.sh/Installation">zde</a>.
     doc:
+      man: <code>man brew</code> documentation
       further: Další dokumentace
       donate: Donate to Homebrew
       blog: Homebrew Blog

--- a/_data/locales/da.yml
+++ b/_data/locales/da.yml
@@ -19,6 +19,7 @@ da:
       paste: Kopier og indsæt i din Terminal.
       what: Scriptet forklarer hvad det vil gøre, og pauser før den gør det. Der findes flere installeringsmuligheder <a href="https://docs.brew.sh/Installation" title="Flere installeringsmuligheder">her</a>.
     doc:
+      man: <code>man brew</code> documentation
       further: Videre dokumentation
       donate: Donate to Homebrew
       blog: Homebrew Blog

--- a/_data/locales/de.yml
+++ b/_data/locales/de.yml
@@ -19,6 +19,7 @@ de:
       paste: Kopiere dies ins Terminal.
       what: Das Skript erklärt dir, was es tun wird und wartet, bevor es etwas macht. Mehr Installationsoptionen findest du <a href="https://docs.brew.sh/Installation">hier</a>.
     doc:
+      man: <code>man brew</code> documentation
       further: Weitere Dokumentation
       donate: An Homebrew spenden
       blog: Homebrew-Blog

--- a/_data/locales/el.yml
+++ b/_data/locales/el.yml
@@ -19,6 +19,7 @@ el:
       paste: Κάντε το επικόλληση στην γραμμή εντολών του macOS Terminal.
       what: Το script εξηγεί τι θα κάνει και στη συνέχεια κάνει μια παύση προτού το κάνει. Διαβάστε σχετικά με άλλες <a href="https://docs.brew.sh/Installation">επιλογές εγκατάστασης</a>.
     doc:
+      man: <code>man brew</code> documentation
       further: Περαιτέρω Οδηγίες
       donate: Κάντε μια δωρεά στο Homebrew
       blog: To blog του Homebrew

--- a/_data/locales/en.yml
+++ b/_data/locales/en.yml
@@ -19,6 +19,7 @@ en:
       paste: Paste that in a macOS Terminal or Linux shell prompt.
       what: The script explains what it will do and then pauses before it does it. Read about other <a href="https://docs.brew.sh/Installation">installation options</a>.
     doc:
+      man: <code>brew</code> command documentation
       further: Further Documentation
       donate: Donate to Homebrew
       blog: Homebrew Blog

--- a/_data/locales/es.yml
+++ b/_data/locales/es.yml
@@ -19,6 +19,7 @@ es:
       paste: Pega este código en una ventana del Terminal.
       what: El programa de instalación va explicando paso a paso el proceso, qué es lo que va a hacer y se toma una pausa para confirmar antes de empezar con cada uno de los pasos. Puedes encontrar más opciones de instalación <a href="https://docs.brew.sh/Installation">aquí</a>.
     doc:
+      man: <code>brew</code> command documentation
       further: Documentos adicionales
       donate: Donar a Homebrew
       blog: Blog de Homebrew

--- a/_data/locales/fa.yml
+++ b/_data/locales/fa.yml
@@ -19,6 +19,7 @@ fa:
       paste: کد بالا را در خط فرمان ترمینال جایگذاری کنید.
       what: اسکریپت قبل از انجام هر مرحله مکث کرده و به توضیح کاری که می‌خواهد انجام دهد می‌پردازد. گزینه‌های بیشتری برای نصب <a href="https://docs.brew.sh/Installation">اینجا</a>  موجود است. نسخه ۱۰.۵ نیاز است.
     doc:
+      man: <code>man brew</code> documentation
       further: مستندات بیشتر
       donate: Donate to Homebrew
       blog: Homebrew Blog

--- a/_data/locales/fi.yml
+++ b/_data/locales/fi.yml
@@ -19,6 +19,7 @@ fi:
       paste: Liitä tämä komentokehotteeseen.
       what: Skripti kertoo mitä tekee ja pysähtyy sen jälkeen odottamaan varmistusta. Lisää asennusvaihtoehtoja löytyy <a href="https://docs.brew.sh/Installation">täältä</a>.
     doc:
+      man: <code>man brew</code> documentation
       further: Laajempi dokumentaatio
       donate: Donate to Homebrew
       blog: Homebrew Blog

--- a/_data/locales/fr.yml
+++ b/_data/locales/fr.yml
@@ -19,6 +19,7 @@ fr:
       paste: Copiez et collez dans une fenêtre du Terminal.
       what: Le script explique ce qu’il va faire, puis fait une pause avant de l’exécuter. Plus d’options d’installation sont disponibles <a href="https://docs.brew.sh/Installation">ici</a>.
     doc:
+      man: <code>man brew</code> documentation
       further: Documentation additionnelle
       donate: Donnez à Homebrew
       blog: Blog Homebrew

--- a/_data/locales/gl.yml
+++ b/_data/locales/gl.yml
@@ -19,6 +19,7 @@ gl:
       paste: Pega este código nunha Terminal.
       what: O <i>script</i> explica o que vai facer e fai unha pausa antes de executar nada. Hai máis opcións de instalación <a href="https://docs.brew.sh/Installation">aquí</a>.
     doc:
+      man: <code>man brew</code> documentation
       further: Documentación adicional
       donate: Donate to Homebrew
       blog: Blog de Homebrew

--- a/_data/locales/he.yml
+++ b/_data/locales/he.yml
@@ -19,6 +19,7 @@ he:
       paste: יש להריץ את הפקודה הבאה במסוף.
       what: הסקריפט יסביר מה הוא יעשה ויעצור לפני שיעשה זאת. קיימות אפשרויות נוספות להתקנה <a href="https://docs.brew.sh/Installation">כאן</a>.
     doc:
+      man: <code>man brew</code> documentation
       further: תיעוד נוסף
       donate: תרומה ל־Homebrew
       blog: הבלוג של Homebrew

--- a/_data/locales/hi.yml
+++ b/_data/locales/hi.yml
@@ -19,6 +19,7 @@ hi:
       paste: इसे एक macOS टर्मिनल या Linux शेल प्रॉम्प्ट में पेस्ट करें।
       what: स्क्रिप्ट बताती है कि वह क्या करेगी और फिर इसे करने से पहले रुक जाती है। अन्य<a href="https://docs.brew.sh/Installation"> स्थापना विकल्प </a>के बारे में पढ़ें।
     doc:
+      man: <code>man brew</code> documentation
       further: आगे का प्रलेखन
       donate: Homebrew को दान करें
       blog: Homebrew ब्लॉग

--- a/_data/locales/id.yml
+++ b/_data/locales/id.yml
@@ -19,6 +19,7 @@ id:
       paste: Tempelkan itu di Terminal macOS atau prompt shell Linux.
       what: Script ini menjelaskan apa yang akan dilakukan dan kemudian berhenti sebelum melakukannya. Baca tentang <a href="https://docs.brew.sh/Installation">opsi penginstalan</a> lainnya.
     doc:
+      man: <code>man brew</code> documentation
       further: Dokumentasi Lebih Lanjut
       donate: Donasikan ke Homebrew
       blog: Blog Homebrew

--- a/_data/locales/it.yml
+++ b/_data/locales/it.yml
@@ -19,6 +19,7 @@ it:
       paste: Incolla questa riga su una finestra del Terminale.
       what: Lo script ti spiega quello che sta facendo e aspetterà un tuo comando. Ci sono ulteriori <a href="https://docs.brew.sh/Installation">opzioni di installazione</a>.
     doc:
+      man: <code>man brew</code> documentation
       further: Ulteriore documentazione
       donate: Donate to Homebrew
       blog: Homebrew Blog

--- a/_data/locales/ja.yml
+++ b/_data/locales/ja.yml
@@ -19,6 +19,7 @@ ja:
       paste: これをmacOSのターミナルまたはLinuxのシェルプロンプトに貼り付けて下さい。
       what: スクリプトは何をするのか説明してから、それを開始する前に一度中断します。その他の<a href="https://docs.brew.sh/Installation">インストールオプション</a>も確認してください。
     doc:
+      man: <code>man brew</code> documentation
       further: さらに詳しいドキュメント
       donate: Homebrewへの寄付
       blog: Homebrewブログ

--- a/_data/locales/ko.yml
+++ b/_data/locales/ko.yml
@@ -19,6 +19,7 @@ ko:
       paste: 터미널에 붙여넣기 하세요.
       what: 해당 스크립트는 무엇을 할지 설명하고 실행하기 전에 잠시 멈춥니다. 더 자세한 설치 옵션사항을 보려면 <a href="https://docs.brew.sh/Installation">여기</a>를 참고하세요.
     doc:
+      man: <code>man brew</code> documentation
       further: 추가 문서
       donate: Homebrew 후원하기
       blog: Homebrew 블로그

--- a/_data/locales/kur.yml
+++ b/_data/locales/kur.yml
@@ -1,6 +1,6 @@
 kur:
   locale_name: کوردی
-  subtitle:  macOS (یان Linux) بەڕێوبەری پاکێجە  
+  subtitle:  macOS (یان Linux) بەڕێوبەری پاکێجە
   pagecontent:
     search: گەڕان
     question: هۆمبریو دەتوانێت چیت بۆ بکات؟
@@ -19,6 +19,7 @@ kur:
       paste: ئەمە بلکێنە لە تێرمیناڵی MacOS یان شێڵی Linux
       what: سکریپتەکە شی دەکاتەوە چی دەکات و دەوەستێت پێش کردنیان. <a href="https://docs.brew.sh/Installation">بڕیارەکانی داگرتن</a>.
     doc:
+      man: <code>man brew</code> documentation
       further: زانیاری زیاتر
       donate: یارمەتیدانی هۆمبریو
       blog: بلۆگی هۆمبریو
@@ -26,5 +27,5 @@ kur:
       formulae: پاکێجەکانی هۆمبریو
       analytics:  شیکردنەوەی داتاکان
     foot:
-      code: <a href="https://mxcl.github.io/">Max Howell</a> هۆمبریو درووست کراوە لە لایەن 
+      code: <a href="https://mxcl.github.io/">Max Howell</a> هۆمبریو درووست کراوە لە لایەن
       page:  <a href="https://exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a> and <a href="https://cargocollective.com/danilalo">Danielle Lalonde</a> وێبسایت لە لایەن

--- a/_data/locales/lb.yml
+++ b/_data/locales/lb.yml
@@ -19,6 +19,7 @@ lb:
       paste: Paste dat heiten an dengem macOS Terminal oder Linux shell prompt.
       what: Den script erklärt wat en maachen wäert an paust éier en et mécht. Et ginn awer och aner <a href="https://docs.brew.sh/Installation">Installatiounsoptiounen</a>.
     doc:
+      man: <code>man brew</code> documentation
       further: Weider Documentatioun
       donate: Stëft Homebrew
       blog: Homebrew Blog

--- a/_data/locales/nb.yml
+++ b/_data/locales/nb.yml
@@ -19,6 +19,7 @@ nb:
       paste: Lim dette inn i din Terminal.
       what: Scriptet forklarer hva det gjør og tar en pause før det gjøres. Du finner flere måter å installere på <a href="https://docs.brew.sh/Installation">her</a>.
     doc:
+      man: <code>man brew</code> documentation
       further: Videre dokumentasjon
       donate: Donate to Homebrew
       blog: Homebrew Blog

--- a/_data/locales/nl.yml
+++ b/_data/locales/nl.yml
@@ -19,6 +19,7 @@ nl:
       paste: Plak het bovenstaande in Terminal.
       what: Het installatiescript beschrijft wat het wil doen en wacht voordat de installatie wordt uitgevoerd. Meer installatie-opties zijn <a href="https://docs.brew.sh/Installation">hier</a>.
     doc:
+      man: <code>man brew</code> documentation
       further: Verdere documentatie
       donate: Donate to Homebrew
       blog: Homebrew-blog

--- a/_data/locales/nn.yml
+++ b/_data/locales/nn.yml
@@ -19,6 +19,7 @@ nn:
       paste: Lim dette inn i terminalen din.
       what: Skriptet forklarar kva det gjer og tek ei pause før det køyrer. Du finn fleire måtar å installere på <a href="https://docs.brew.sh/Installation">her</a>.
     doc:
+      man: <code>man brew</code> documentation
       further: Vidare dokumentasjon
       donate: Støtt Homebrew
       blog: Homebrew Blogg

--- a/_data/locales/pl.yml
+++ b/_data/locales/pl.yml
@@ -19,6 +19,7 @@ pl:
       paste: Wklej polecenie w swoim Terminalu.
       what: Skrypt instalacyjny wyjaśnia jakie zmiany zamierza wprowadzić, po czym zatrzymuje się czekając na ich akceptację. Po więcej opcji instalacji zajrzyj <a href="https://docs.brew.sh/Installation">tutaj</a>.
     doc:
+      man: <code>man brew</code> documentation
       further: Dalsza dokumentacja
       donate: Darowizna na Homebrew
       blog: Blog Homebrew

--- a/_data/locales/pt-br.yml
+++ b/_data/locales/pt-br.yml
@@ -19,6 +19,7 @@ pt-br:
       paste: Copie esse código para um prompt do seu Terminal.
       what: O script explica o que irá fazer e faz uma pausa antes de ser executado. Há mais opções de instalação <a href="https://docs.brew.sh/Installation">aqui</a>.
     doc:
+      man: <code>man brew</code> documentation
       further: Documentos Adicionais
       donate: Doe ao Homebrew
       blog: Blog do Homebrew

--- a/_data/locales/ro.yml
+++ b/_data/locales/ro.yml
@@ -19,6 +19,7 @@ ro:
       paste: Copiază asta într-un terminal macOS sau Linux.
       what: Scriptul îți explică ce vrea să facă și va lua o pauză înainte de a continua. Citește despre alte <a href="https://docs.brew.sh/Installation">opțiuni de instalare</a>.
     doc:
+      man: <code>man brew</code> documentation
       further: Documentație suplimentară
       donate: Donează către Homebrew
       blog: Blog Homebrew

--- a/_data/locales/ru.yml
+++ b/_data/locales/ru.yml
@@ -19,6 +19,7 @@ ru:
       paste: Вставьте эту строку в терминал.
       what: Перед выполнением скрипт объяснит, что он собирается сделать. Другие варианты установки можно найти <a href="https://docs.brew.sh/Installation">здесь</a>.
     doc:
+      man: <code>man brew</code> documentation
       further: Остальная документация
       donate: Пожертвовать на развитие Homebrew
       blog: Блог Homebrew

--- a/_data/locales/sr.yml
+++ b/_data/locales/sr.yml
@@ -19,6 +19,7 @@ sr:
       paste: Налепите ово у прозор Терминала.
       what: Скрипта ће да се паузира и објасни шта ради пре него што то и уради. Више опција за инсталацију постоји <a href="https://docs.brew.sh/Installation">овде</a>.
     doc:
+      man: <code>man brew</code> documentation
       further: Даља Документација
       donate: Donate to Homebrew
       blog: Homebrew Блог

--- a/_data/locales/sv.yml
+++ b/_data/locales/sv.yml
@@ -19,6 +19,7 @@ sv:
       paste: Klistra in skriptet ovan i en macOS Terminal kommandotolk.
       what: Skriptet förklarar vad den installerar och pausar före installationen. Läs mer om <a href="https://docs.brew.sh/Installation">installationsalternativen</a> som finns tillgängliga.
     doc:
+      man: <code>man brew</code> documentation
       further: Vidare Dokumentation
       donate: Donera till Homebrew
       blog: Homebrew Bloggen

--- a/_data/locales/th.yml
+++ b/_data/locales/th.yml
@@ -19,6 +19,7 @@ th:
       paste: คัดลอกคำสั่งด้านบนไปรันใน Terminal
       what: สคริปจะมีการอธิบายให้รู้ก่อนว่ากำลังจะทำอะไร จากนั้นจะหยุดถามก่อนที่มันจะเริ่มทำ สามารถดูตัวเลือกในการติดตั้งต่าง ๆ ได้จาก<a href="https://docs.brew.sh/Installation">ที่นี่</a>
     doc:
+      man: <code>man brew</code> documentation
       further: เอกสารอื่น ๆ
       donate: สมทบทุนให้กับ Homebrew
       blog: บล็อกของ Homebrew

--- a/_data/locales/tr.yml
+++ b/_data/locales/tr.yml
@@ -19,6 +19,7 @@ tr:
       paste: Üstteki kod parçacığını bir Terminal penceresine yapıştırın.
       what: Betik yapacaklarını açıklayıp, sizden komut bekler. <a href="https://docs.brew.sh/Installation">Burada</a> diğer kurulum seçeneklerini de bulabilirsiniz.
     doc:
+      man: <code>man brew</code> documentation
       further: İlave Dokümantasyon
       donate: Homebrew’e Bağış Yapın
       blog: Homebrew Blogu

--- a/_data/locales/uk.yml
+++ b/_data/locales/uk.yml
@@ -19,6 +19,7 @@ uk:
       paste: Запустіть цей код в Terminal.
       what: Перш ніж робити будь-які зміни, скрипт зупиниться для пояснення, що саме буде зроблено. Більше способів установлення описані <a href="https://docs.brew.sh/Installation">тут</a>.
     doc:
+      man: <code>man brew</code> documentation
       further: Більше документації
       donate: Підтримати Homebrew
       blog: Блог Homebrew

--- a/_data/locales/vi.yml
+++ b/_data/locales/vi.yml
@@ -19,6 +19,7 @@ vi:
       paste: Dán nó vào hiện thị của Terminal.
       what: Đoạn script giải thích các bước sẽ được thực hiện và sẽ dừng trước khi thực thi. Có nhiều lựa chọn cài đặt <a href="https://docs.brew.sh/Installation">ở đây</a>.
     doc:
+      man: <code>man brew</code> documentation
       further: Tra khảo thêm
       donate: Donate to Homebrew
       blog: Homebrew Blog

--- a/_data/locales/zh-cn.yml
+++ b/_data/locales/zh-cn.yml
@@ -19,6 +19,7 @@ zh-cn:
       paste: 将以上命令粘贴至终端。
       what: 脚本会在执行前暂停，并说明它将做什么。高级安装选项在 <a href="https://docs.brew.sh/Installation">这里</a>。
     doc:
+      man: <code>man brew</code> documentation
       further: 更多文档
       donate: 捐赠给 Homebrew
       blog: Homebrew 博客

--- a/_data/locales/zh-tw.yml
+++ b/_data/locales/zh-tw.yml
@@ -19,6 +19,7 @@ zh-tw:
       paste: 在終端機命令列提示貼上這個。
       what: 腳本執行時會解釋它正在做什麼，並在你確認之前暫停下來。你可以在<a href="https://docs.brew.sh/Installation">這裡</a>找到更多安裝選擇。
     doc:
+      man: <code>man brew</code> documentation
       further: 更多說明文件
       donate: Donate to Homebrew
       blog: Homebrew Blog

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -151,18 +151,18 @@ Editing /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/foo.rb
 
     <li>
       <div class="group row">
-        <h2 id="further-doc">{{ t.pagecontent.doc.further }}</h2>
+        <h2 id="further-doc">{{ t.pagecontent.doc.man }}</h2>
         <div class="button">
-          <p><a href="https://docs.brew.sh">docs.brew.sh</a></p>
+          <p><a href="https://docs.brew.sh/Manpage">docs.brew.sh/Manpage</a></p>
         </div>
       </div>
     </li>
 
     <li>
       <div class="group row">
-        <h2 id="homebrew-donate">{{ t.pagecontent.doc.donate }}</h2>
+        <h2 id="further-doc">{{ t.pagecontent.doc.further }}</h2>
         <div class="button">
-          <p><a href="https://github.com/homebrew/brew#donations">Homebrew/brew#donations</a></p>
+          <p><a href="https://docs.brew.sh">docs.brew.sh</a></p>
         </div>
       </div>
     </li>
@@ -206,6 +206,15 @@ Editing /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/foo.rb
     <li>
       <div class="group row credits">
         <p>{{ t.pagecontent.foot.code }} {{ t.pagecontent.foot.page }}<br>{{ t.pagecontent.foot.translation }}</p>
+      </div>
+    </li>
+
+    <li>
+      <div class="group row">
+        <h2 id="homebrew-donate">{{ t.pagecontent.doc.donate }}</h2>
+        <div class="button">
+          <p><a href="https://github.com/homebrew/brew#donations">Homebrew/brew#donations</a></p>
+        </div>
       </div>
     </li>
   </ul>

--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -50,6 +50,10 @@ h1, h2, h3 {
   margin: 0 0 0.1em;
   text-align: center;
   text-shadow: 1px 1px 10px $black_25;
+
+  code {
+    font-size: 120%;
+  }
 }
 
 h1, h2, h3, h4, h5, h6 {


### PR DESCRIPTION
This is the most useful documentation for most users so let's make it the first bullet at the end of the homepage (and make it look nice).

Let's also move the donation bullet to the bottom.