### PR TITLE
Revert "index: temporarily change install URL"

### DIFF
--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -9,7 +9,7 @@ layout: base
         <h2 id="install">{{ t.pagecontent.install.install }}</h2>
         <br>
         <div class="copyable">
-          {%- highlight bash -%} /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)" {%- endhighlight -%}
+          {%- highlight bash -%} /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" {%- endhighlight -%}
         </div>
         <br>
         <br>


### PR DESCRIPTION
Reverts Homebrew/brew.sh#879

GitHub have rolled out a fix. Everything should be working now.