### PR TITLE
Fix `html-proofer` use in tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,15 +13,11 @@ task test: :build do
   HTMLProofer.check_directory(
     "./_site",
     parallel: { in_threads: 4 },
-    favicon: true,
-    http_status_ignore: [0, 302, 303, 429, 521],
-    assume_extension: true,
+    ignore_status_codes: [0, 302, 303, 429, 521],
     check_external_hash: true,
-    check_favicon: true,
-    check_opengraph: true,
-    check_html: true,
-    check_img_http: true,
-    url_ignore: [
+    checks: ['Links', 'Images', 'Scripts', 'Favicon', 'OpenGraph'],
+    allow_missing_href: true,
+    ignore_urls: [
       "https://formulae.brew.sh/",
       "https://github.com/search",
       "https://hackerone.com/homebrew",

--- a/_data/locales/tr.yml
+++ b/_data/locales/tr.yml
@@ -29,4 +29,4 @@ tr:
     foot:
       code: Özgün kodu yazan <a href="https://mxcl.github.io/">Max Howell</a>.
       page: Siteyi hazırlayanlar <a href="https://exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a>, <a href="https://cargocollective.com/danilalo">Danielle Lalonde</a>.
-      translation: Tercüme edenler <a href="https://github.com/hemlockII">hemlockII</a>, <a href="https://ziyaddin.github.io">Ziyaddin Sadigov</a>, <a href="https://github.com/quaertym">Emre Ünal</a>, <a href="http://serkan.io">Serkan Yerşen</a>, <a href="https://github.com/okan">Okan</a>, <a href="https://enderahmetyurt.com">Ender Ahmet Yurt</a>, <a href="https://sadikkuzu.com">Sadık Kuzu</a>.
+      translation: Tercüme edenler <a href="https://github.com/hemlockII">hemlockII</a>, <a href="https://ziyaddin.github.io">Ziyaddin Sadigov</a>, <a href="https://github.com/quaertym">Emre Ünal</a>, <a href="https://serkan.io">Serkan Yerşen</a>, <a href="https://github.com/okan">Okan</a>, <a href="https://enderahmetyurt.com">Ender Ahmet Yurt</a>, <a href="https://sadikkuzu.com">Sadık Kuzu</a>.

--- a/_posts/2017-05-01-homebrew-1.2.0.md
+++ b/_posts/2017-05-01-homebrew-1.2.0.md
@@ -57,6 +57,6 @@ And finally:
 - [Homebrew's mailing list has been deprecated in favour of our Discourse forum](https://discourse.brew.sh)
 - [Homebrew accepts donations through Patreon](https://www.patreon.com/homebrew). If you can afford it, please consider donating.
 - [Homebrew uses HackerOne for security vulnerability disclosure](https://hackerone.com/homebrew)
-- Homebrew's CI servers are now provided by [MacStadium](https://www.macstadium.com/) and [DigitalOcean](https://www.digitalocean.com). Thanks to [Positive Internet](http://www.positive-internet.com) for years of friendship, incredible customer support and super reliable hosting.
+- Homebrew's CI servers are now provided by [MacStadium](https://www.macstadium.com/) and [DigitalOcean](https://www.digitalocean.com). Thanks to [Positive Internet](https://www.positive-internet.com) for years of friendship, incredible customer support and super reliable hosting.
 
 Thanks to all our hard-working maintainers, contributors, sponsors and supporters for getting us this far. Enjoy using Homebrew!

--- a/_posts/2021-02-05-homebrew-3.0.0.md
+++ b/_posts/2021-02-05-homebrew-3.0.0.md
@@ -28,7 +28,7 @@ Other changes since 2.7.0 I'd like to highlight are the following:
 
 Finally:
 
-- [Discourse](http://discourse.brew.sh) was made read-only on January 1st 2021 in favour of [GitHub Discussions](https://github.com/Homebrew/discussions/discussions).
+- [Discourse](https://discourse.brew.sh) was made read-only on January 1st 2021 in favour of [GitHub Discussions](https://github.com/Homebrew/discussions/discussions).
 - [Homebrew accepts donations through GitHub Sponsors](https://github.com/sponsors/Homebrew) and [still accepts donations through Patreon](https://www.patreon.com/homebrew). If you can afford it, please consider donating. If you'd rather not use GitHub Sponsors or Patreon (our preferred donation methods), [check out the other ways to donate in our README](https://github.com/homebrew/brew/#donations).
 
 Thanks to all our hard-working maintainers, contributors, sponsors and supporters for getting us this far. Particular thanks on Homebrew 3.0.0 go to MacStadium and Apple for providing us with a lot of Apple Silicon hardware and Cassidy from Apple for helping us in many ways with this migration. Enjoy using Homebrew!


### PR DESCRIPTION
CI currently [fails](https://github.com/Homebrew/brew.sh/runs/7394015282?check_suite_focus=true) because of issues with `html-parser` [since version 4 was released](https://github.com/gjtorikian/html-proofer/blob/main/UPGRADING.md). I've updated the configuration to be as similar as possible. The main changes: I updated a few options that had been renamed. I removed some options that are now the default or have different functionality. I removed the `check_html` line since the HTML checks [were completely removed](https://github.com/gjtorikian/html-proofer/pull/670) and also removed the `favicon` option since I believe it is covered by including `'Favicon'` in the list of checks.

I needed to set the `allow_missing_href` option since we have several `<link>` attributes without an `href` specified in the translation files. There may be a better way to fix this, but I don't know it off the top of my head.

Finally, I updated a few URLs to use `https`. However, I noticed that the URL http://serkan.io (the homepage for [Serkan Yerşen, one of the translators for Turkish](https://github.com/Homebrew/brew.sh/blob/c68fc5b7c738608b1a94d0d7fb0a2dbc734cc850/_data/locales/tr.yml#L32)) doesn't seem to work for me regardless of whether I use `http` or `https`. I changed it anyway to pass the checks, though.