### PR TITLE
Fix search result overflow

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -22,7 +22,7 @@ algolia:
     {% endif %}
     {% seo title=false %}
     {% feed_meta %}
-    <meta name="viewport" content="width=device-width">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/x-icon" href="{{ "/assets/img/favicon.ico" | relative_url }}">
     <link rel="apple-touch-icon" href="{{ "/assets/img/apple-touch-icon.png" | relative_url }}">
     <link rel="stylesheet" href="{{ "/assets/css/styles.css" | relative_url }}" type="text/css" media="screen">

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -22,7 +22,7 @@ algolia:
     {% endif %}
     {% seo title=false %}
     {% feed_meta %}
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width">
     <link rel="icon" type="image/x-icon" href="{{ "/assets/img/favicon.ico" | relative_url }}">
     <link rel="apple-touch-icon" href="{{ "/assets/img/apple-touch-icon.png" | relative_url }}">
     <link rel="stylesheet" href="{{ "/assets/css/styles.css" | relative_url }}" type="text/css" media="screen">

--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -693,7 +693,7 @@ div .algolia-autocomplete {
   }
 }
 
-#algolia-autocomplete-listbox-0 {
+.algolia-autocomplete.algolia-autocomplete-right .ds-dropdown-menu {
   min-width: 50vw;
 }
 

--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -693,4 +693,8 @@ div .algolia-autocomplete {
   }
 }
 
+#algolia-autocomplete-listbox-0 {
+  min-width: 50vw;
+}
+
 @import "pygments.scss";


### PR DESCRIPTION
Currently, the search result may overflow on small screens:

<img width="448" alt="image" src="https://user-images.githubusercontent.com/44045911/190900479-ef46abdc-8260-4cf0-85b8-8ab5629644ce.png">

This pull request limits the width of search results, and set a initial scale to prevent similar overflows in the future:

<img width="450" alt="image" src="https://user-images.githubusercontent.com/44045911/190900550-2ae134e5-78ee-4928-9878-8fdbf4ea83b1.png">

To be honest this does not look the best, but it's better than overflowing.