### PR TITLE
Fix search result overflow /2

### DIFF
--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -693,8 +693,8 @@ div .algolia-autocomplete {
   }
 }
 
-.algolia-autocomplete.algolia-autocomplete-right .ds-dropdown-menu {
-  min-width: 50vw;
+.algolia-autocomplete .ds-dropdown-menu {
+  min-width: 50vw !important;
 }
 
 @import "pygments.scss";


### PR DESCRIPTION
This is a follow up to #893. I didn't correctly test the change in [`472569b` (#893)](https://github.com/Homebrew/brew.sh/pull/893/commits/472569b1d2f9720d746d6e3982a56a89fd2e0980), this pull request fixes it.

Algolia adds a `.algolia-autocomplete-right` class on large screens, while using `.algolia-autocomplete-left` on small screens, so the current selector does nothing in the latter case.