### PR TITLE
security.txt: Link to GitHub rather than HackerOne

### DIFF
--- a/security.txt
+++ b/security.txt
@@ -3,8 +3,8 @@ layout: none
 permalink: .well-known/security.txt
 ---
 {% capture plus_1_month %}{{ site.time | date: '%s' | plus: 2678400 }}{% endcapture %}
-Contact: https://hackerone.com/homebrew/
+Contact: https://github.com/Homebrew/brew/security/advisories/new
 Expires: {{ plus_1_month | date_to_rfc822 }}
 Acknowledgments: https://hackerone.com/homebrew/thanks
 Preferred-Languages: en
-Policy: https://hackerone.com/homebrew?view_policy=true
+Policy: https://github.com/Homebrew/.github/blob/HEAD/SECURITY.md


### PR DESCRIPTION
- The only link I didn't change is the thanks one because it's probably nice to keep previous reporters acknowledged? Can we import historical HackerOne reports into GitHub for that purpose, or something?