### PR TITLE
Search: do not set Algolia lang attribute

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -134,7 +134,7 @@ algolia:
 
       function loadSearch(lang, site) {
         docsearch(Object.assign(
-          { algoliaOptions: { facetFilters: ['lang: ' + lang, 'site: ' + site] } },
+          { algoliaOptions: { facetFilters: ['site: ' + site] } },
           {{ layout.algolia | jsonify }}
         ));
         window.location.hash || document.querySelector("#search-bar").focus();


### PR DESCRIPTION
As pointed out by https://github.com/Homebrew/brew.sh/issues/899#issuecomment-1311246326, this attribute prevents us from crawling most of the site when viewed in non-English languages because we don't translate the package database, documentation, etc.

Without this PR, if you set the homepage to any non-English language, you won't be able to search for any package names. With this PR, search should work.

Fixes #899.