### PR TITLE
HTML proofer: allow a few known-dead links in old posts

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -23,6 +23,10 @@ task test: :build do
       "https://hackerone.com/homebrew",
       "https://www.patreon.com/homebrew",
       %r{^https?://twitter\.com/},
+      %r{https://github.com/Homebrew/homebrew-science/.+},
+      %r{https://github.com/Homebrew/brew/.+},
+      "https://github.com/mrtnpwn",
+      "https://github.com/homebrew/homebrew-php",
     ]
   ).run
 end


### PR DESCRIPTION
As seen in #908, a few of our old links have died since we wrote the old posts they're linked in. That's fine: we can just tell HTML Proofer to ignore them.