### PR TITLE
Update Kurdish language code to ISO 639-1

### DIFF
--- a/_data/locales/ku.yml
+++ b/_data/locales/ku.yml
@@ -1,4 +1,4 @@
-kur:
+ku:
   locale_name: کوردی
   subtitle:  macOS (یان Linux) بەڕێوبەری پاکێجە
   pagecontent:

--- a/index_ku.html
+++ b/index_ku.html
@@ -1,4 +1,4 @@
 ---
 layout: index
-lang: kur
+lang: ku
 ---


### PR DESCRIPTION
The files related to the Kurdish localization use `kur` as the language code but this should be `ku`. This mismatch leads to a validation error ("Bad value `kur` for attribute `hreflang` on element `link`: The language subtag `kur` is not a valid ISO language part of a language tag.") and this change resolves the issue.