### PR TITLE
Loosen homebrew-science dead link regex

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -23,7 +23,7 @@ task test: :build do
       "https://hackerone.com/homebrew",
       "https://www.patreon.com/homebrew",
       %r{^https?://twitter\.com/},
-      %r{https://github.com/Homebrew/homebrew-science/.+},
+      %r{https://github.com/Homebrew/homebrew-science(?:/.+)?},
       %r{https://github.com/Homebrew/brew/.+},
       "https://github.com/mrtnpwn",
       "https://github.com/homebrew/homebrew-php",


### PR DESCRIPTION
CI is failing in #910 in relation to `html-proofer` with an `External link https://github.com/Homebrew/homebrew-science failed (status code 404)` error. #909 appeared to be intended to address this but the related regex in the `Rakefile` doesn't match the Homebrew/homebrew-science URL when it doesn't end with a forward slash and trailing text.

This PR modifies the related regex to make the forward slash and trailing text optional, so it will also match the aforementioned URL.