### PR TITLE
Remove duplicate further-doc id attribute

### DIFF
--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -151,7 +151,7 @@ Editing /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/foo.rb
 
     <li>
       <div class="group row">
-        <h2 id="further-doc">{{ t.pagecontent.doc.man }}</h2>
+        <h2>{{ t.pagecontent.doc.man }}</h2>
         <div class="button">
           <p><a href="https://docs.brew.sh/Manpage">docs.brew.sh/Manpage</a></p>
         </div>


### PR DESCRIPTION
The main `index.html` page contains two elements with a `further-doc` `id` attribute. IDs in HTML must be unique, so this leads to a validation error. This commit removes the ID from the element where it seems less appropriate.