### PR TITLE
Use "en" as default lang

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -6,7 +6,7 @@ algolia:
 ---
 {% assign t = site.data.locales[page.lang][page.lang] %}
 <!DOCTYPE html>
-<html {% if page.direction == "rtl" %}dir="rtl" {% endif %}lang="{{ page.lang }}">
+<html {% if page.direction == "rtl" %}dir="rtl" {% endif %}lang="{{ page.lang | default: "en" }}">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     {% if page.title %}


### PR DESCRIPTION
Post HTML currently renders with an empty `lang` attribute (i.e., `<html lang="">`) and this produces a validation warning:

> This document appears to be written in English but the `html` start tag has an empty `lang` attribute. Consider using `lang="en"` (or variant) instead.

When a `lang` value isn't provided in the front matter, we should either use `en` as the default or omit the `lang` attribute. There's something to be said for using `lang="en"` rather than omitting, so this PR uses that approach.