### PR TITLE
Replace use of device-width

### DIFF
--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -540,7 +540,7 @@ span .amp {
   padding: 0.1em;
   text-align: center;
   width: 25em;
-  @media only screen and (max-device-width: 480px) {
+  @media only screen and (max-width: 480px) {
     width: 12em;
   }
 }


### PR DESCRIPTION
The `device-width` CSS media feature is considered deprecated and `width` (e.g., `max-width`) is recommended instead. This PR updates the related `media` query accordingly, resolving a validation error.