### PR TITLE
Change homepage title text order

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -12,7 +12,7 @@ algolia:
     {% if page.title %}
     <title>{{ page.title }} — {{ site.title }}</title>
     {% elsif t.subtitle %}
-    {% if page.direction == "rtl" %}
+    {% if page.url == "/" or page.direction == "rtl" %}
     <title>{{ site.title }} — {{ t.subtitle }}</title>
     {% else %}
     <title>{{ t.subtitle }} — {{ site.title }}</title>


### PR DESCRIPTION
The subtitle comes before the site title in the homepage `title` element, so "Homebrew" comes at the very end (i.e., "The Missing Package Manager for macOS (or Linux) — Homebrew"). This is fine for post titles but "Homebrew" should arguably be the first text of the homepage title, as the full text isn't visible in some common scenarios (e.g., browser tabs, some search results, etc.) and we likely want to prioritize the project name for the homepage.