### PR TITLE
Remove unnecessary script type attribute

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -165,8 +165,7 @@ algolia:
             integrity="sha256-m1eTvwEHwmsw4+XKF7BshClVJEPwTVycveNl0CS0Mkk="
             crossorigin="anonymous"
             onload="loadAnchors()" async></script>
-    <script type="text/javascript"
-            src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"
+    <script src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"
             onload="loadSearch('{{ page.lang }}', '{{ page.search_site }}')" async></script>
   </body>
 </html>


### PR DESCRIPTION
The `type` attribute is unnecessary for `script` elements in HTML5 and using it produces a validation warning. We don't use the `type` attribute with any other `script` elements, so this change brings this element in line with the others.

In practical terms, this is a validation warning that we see across any file using the base template, so it appears in many files and adds a lot of noise to validation checks that aren't restricted to only errors.