### PR TITLE
Improve formatting of generated files

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -4,31 +4,31 @@ algolia:
   indexName: brew_all
   inputSelector: '#search-bar'
 ---
-{% assign t = site.data.locales[page.lang][page.lang] %}
+{% assign t = site.data.locales[page.lang][page.lang] -%}
 <!DOCTYPE html>
 <html {% if page.direction == "rtl" %}dir="rtl" {% endif %}lang="{{ page.lang | default: "en" }}">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    {% if page.title %}
+    {% if page.title -%}
     <title>{{ page.title }} — {{ site.title }}</title>
-    {% elsif t.subtitle %}
-    {% if page.url == "/" or page.direction == "rtl" %}
+    {% elsif t.subtitle -%}
+    {% if page.url == "/" or page.direction == "rtl" -%}
     <title>{{ site.title }} — {{ t.subtitle }}</title>
-    {% else %}
+    {% else -%}
     <title>{{ t.subtitle }} — {{ site.title }}</title>
-    {% endif %}
-    {% else %}
+    {% endif -%}
+    {% else -%}
     <title>{{ site.title }}</title>
-    {% endif %}
-    {% seo title=false %}
+    {% endif -%}
+    {% seo title=false -%}
     {% feed_meta %}
     <meta name="viewport" content="width=device-width">
     <link rel="icon" type="image/x-icon" href="{{ "/assets/img/favicon.ico" | relative_url }}">
     <link rel="apple-touch-icon" href="{{ "/assets/img/apple-touch-icon.png" | relative_url }}">
     <link rel="stylesheet" href="{{ "/assets/css/style.css" | relative_url }}" type="text/css" media="screen">
-    {% if site.url == "http://localhost:4000" %}
+    {% if site.url == "http://localhost:4000" -%}
     <script src="https://github.com/Khan/tota11y/releases/download/0.1.3/tota11y.min.js"></script>
-    {% endif %}
+    {% endif -%}
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -38,39 +38,38 @@ algolia:
       ga('create', 'UA-76679469-2', 'auto');
       ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
-
     </script>
-    {% if site.data.locales and page.lang %}
-    {% assign locales = site.data.locales | sort %}
-    {% for locale in locales %}
-      {% assign lang = locale[0] %}
-      {% if lang == "en" %}
+    {% if site.data.locales and page.lang -%}
+    {% assign locales = site.data.locales | sort -%}
+    {% for locale in locales -%}
+      {% assign lang = locale[0] -%}
+      {% if lang == "en" -%}
       <link rel="alternate" hreflang="en" href="{{ site.url }}" />
       <link rel="alternate" hreflang="x-default" href="{{ site.url }}" />
-      {% else %}
+      {% else -%}
       <link rel="alternate" hreflang="{{ lang }}" href="{{ lang | prepend: '/index_' | prepend: site.url }}" />
-      {% endif %}
-    {% endfor %}
-    {% endif %}
+      {% endif -%}
+    {% endfor -%}
+    {% endif -%}
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css"/>
   </head>
   <body onload="setupCopyables()">
     <div id="wrap">
       <div id="header" class="{{ page.header-class }}">
-        {% if page.logo %}
+        {% if page.logo -%}
         <img alt="{{ page.title }} logo" src="{{ page.logo | relative_url }}" width="128" height="128">
-        {% elsif site.logo %}
+        {% elsif site.logo -%}
         <img alt="{{ site.title }} logo" src="{{ site.logo | relative_url }}" width="128" height="128">
-        {% else %}
+        {% else -%}
         <img alt="Homebrew logo" src="{{ "/assets/img/homebrew-256x256.png" | relative_url }}" width="128" height="128">
-        {% endif %}
+        {% endif -%}
         <h1><a href="{{ site.baseurl }}/">{{ site.title }}</a></h1>
-        {% if t.subtitle %}
+        {% if t.subtitle -%}
         <p id="subtitle"><strong>{{ t.subtitle }}</strong></p>
-        {% endif %}
+        {% endif -%}
         <div>
           <input
-            {% if page.direction == "rtl" %}dir="rtl" {% endif %}
+            {% if page.direction == "rtl" %}dir="rtl"{% endif %}
             type="search"
             name="search-bar"
             id="search-bar"
@@ -78,39 +77,38 @@ algolia:
           />
         </div>
 
-        {% if page.lang %}
+        {% if page.lang -%}
         <select id="language" onchange="loadLanguage(this.options[this.selectedIndex].value)">
-          {% for locale in locales %}
-            {% assign lang = locale[0] %}
-            {% assign locale_name = locale[1][lang].locale_name %}
-            {% if page.lang == lang %}
+          {% for locale in locales -%}
+            {% assign lang = locale[0] -%}
+            {% assign locale_name = locale[1][lang].locale_name -%}
+            {% if page.lang == lang -%}
             <option value="{{ lang }}" selected="selected">{{ locale_name }}</option>
-            {% else %}
+            {% else -%}
             <option value="{{ lang }}">{{ locale_name }}</option>
-            {% endif %}
-          {% endfor %}
+            {% endif -%}
+          {% endfor -%}
         </select>
-        {% endif %}
+        {% endif -%}
       </div>
 
       {{ content }}
-
     </div>
 
-    {% if site.forkme_nwo %}
+    {% if site.forkme_nwo -%}
       {% assign forkme_url = "https://github.com/" |
-                             append: site.forkme_nwo %}
-    {% elsif site.github.repository_nwo and site.github.source.branch and site.github.source.path %}
+                             append: site.forkme_nwo -%}
+    {% elsif site.github.repository_nwo and site.github.source.branch and site.github.source.path -%}
       {% assign forkme_url = "https://github.com/" |
                              append: site.github.repository_nwo |
                              append: "/edit/" |
                              append: site.github.source.branch |
                              append: site.github.source.path |
                              append: "/" |
-                             append: page.path %}
-    {% else %}
-      {% assign forkme_url = "https://github.com/Homebrew/brew" %}
-    {% endif %}
+                             append: page.path -%}
+    {% else -%}
+      {% assign forkme_url = "https://github.com/Homebrew/brew" -%}
+    {% endif -%}
 
     <a href="{{ forkme_url }}"><img id="forkme" src="https://aral.github.io/fork-me-on-github-retina-ribbons/right-grey@2x.png" alt="Fork me on GitHub"></a>
     <script>

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -1,7 +1,7 @@
 ---
 layout: base
 ---
-{% assign t = site.data.locales[page.lang][page.lang] %}
+{% assign t = site.data.locales[page.lang][page.lang] -%}
 <div id="information">
   <ul>
     <li>
@@ -30,9 +30,9 @@ layout: base
           <p>{{ t.pagecontent.what }}</p>
         </div>
         <div class="col-2">
-{% highlight bash %}
+{% highlight bash -%}
 $ brew install wget
-{% endhighlight %}
+{%- endhighlight %}
         </div>
       </div>
     </li>
@@ -43,7 +43,7 @@ $ brew install wget
           <p>{{ t.pagecontent.how }}</p>
         </div>
         <div class="col-2">
-{% highlight bash %}
+{% highlight bash -%}
 $ cd /usr/local
 $ find Cellar
 Cellar/wget/1.16.1
@@ -52,7 +52,7 @@ Cellar/wget/1.16.1/share/man/man1/wget.1
 
 $ ls -l bin
 bin/wget -> ../Cellar/wget/1.16.1/bin/wget
-{% endhighlight %}
+{%- endhighlight %}
         </div>
       </div>
     </li>
@@ -71,10 +71,10 @@ bin/wget -> ../Cellar/wget/1.16.1/bin/wget
           <p>{{ t.pagecontent.createpackages }}</p>
         </div>
         <div class="col-2">
-{% highlight bash %}
+{% highlight bash -%}
 $ brew create https://foo.com/foo-1.0.tgz
 Created /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/foo.rb
-{% endhighlight %}
+{%- endhighlight %}
         </div>
       </div>
     </li>
@@ -85,9 +85,9 @@ Created /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/foo.rb
           <p>{{ t.pagecontent.hack }}</p>
         </div>
         <div class="col-2">
-{% highlight bash %}
+{% highlight bash -%}
 $ brew edit wget # {{ t.pagecontent.editor }}
-{% endhighlight %}
+{%- endhighlight %}
         </div>
       </div>
     </li>
@@ -98,7 +98,7 @@ $ brew edit wget # {{ t.pagecontent.editor }}
           <p>{{ t.pagecontent.formula }}</p>
         </div>
         <div class="col-2">
-{% highlight ruby %}
+{% highlight ruby -%}
 class Wget < Formula
   homepage "https://www.gnu.org/software/wget/"
   url "https://ftp.gnu.org/gnu/wget/wget-1.15.tar.gz"
@@ -109,7 +109,7 @@ class Wget < Formula
     system "make", "install"
   end
 end
-{% endhighlight %}
+{%- endhighlight %}
         </div>
       </div>
     </li>
@@ -128,9 +128,9 @@ end
           <p>{{ t.pagecontent.caskinstall }}</p>
         </div>
         <div class="col-2">
-{% highlight bash %}
+{% highlight bash -%}
 $ brew install --cask firefox
-{% endhighlight %}
+{%- endhighlight %}
         </div>
       </div>
     </li>
@@ -141,10 +141,10 @@ $ brew install --cask firefox
           <p>{{ t.pagecontent.caskcreate }}</p>
         </div>
         <div class="col-2">
-{% highlight bash %}
+{% highlight bash -%}
 $ brew create --cask https://foo.com/foo-1.0.dmg
 Editing /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/foo.rb
-{% endhighlight %}
+{%- endhighlight %}
         </div>
       </div>
     </li>

--- a/blog/index.html
+++ b/blog/index.html
@@ -3,7 +3,7 @@ title: Homebrew
 layout: base
 ---
 <ul class="posts">
-{% for post in site.posts %}
+{% for post in site.posts -%}
   <li>
     <a href="{{ post.url }}" title="{{ post.title }}">
       <h2>
@@ -15,7 +15,7 @@ layout: base
     <br/>
     <div class="clearboth"></div>
   </li>
-{% endfor %}
+{% endfor -%}
 </ul>
 
 {%- include newsletter.html -%}

--- a/security.txt
+++ b/security.txt
@@ -2,7 +2,7 @@
 layout: none
 permalink: .well-known/security.txt
 ---
-{% capture plus_1_month %}{{ site.time | date: '%s' | plus: 2678400 }}{% endcapture %}
+{% capture plus_1_month %}{{ site.time | date: '%s' | plus: 2678400 }}{% endcapture -%}
 Contact: https://github.com/Homebrew/brew/security/advisories/new
 Expires: {{ plus_1_month | date_to_rfc822 }}
 Acknowledgments: https://hackerone.com/homebrew/thanks


### PR DESCRIPTION
This PR modifies Liquid tags in templates to control whitespace using `-` (e.g., `-%}`), so we don't end up with unnecessary blank lines in generated files. In general, the HTML output should be more readable while also having a smaller file size. There are some technical limitations that prevent us from producing *perfectly* formatted HTML but this is subjectively nicer than the status quo and makes it easier to look through the generated HTML files while debugging.

For what it's worth, this is mostly geared toward improving developer experience while debugging, as all of the unnecessary whitespace from the Liquid tags made the generated files hard to go through. If we wanted to properly reduce the size of files on the production website, we could consider adding a minification step to CI (i.e., so the files are still readable when doing local development but optimized on the deployed site). However, there are other ways to reduce the overall download size of our site (outside of minification) that I'm pursuing first.

-----

~Past that, this modifies the indentation of code blocks in templates so that the generated HTML uses more predictable indentation. In `_layouts/index.html`, this is as simple as indenting the code blocks.~

~However, in `_layouts/base.html`, this involves removing one step of indentation in a couple of `for` loops. This improves the format of the HTML output but the code in the template may be a little harder to read with only one level of indentation. That said, these changes align with how we handle multi-level conditional tags in the `head`.~