### PR TITLE
Adjust whitespace for readability/consistency

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -10,15 +10,15 @@ algolia:
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     {% if page.title -%}
-    <title>{{ page.title }} — {{ site.title }}</title>
+      <title>{{ page.title }} — {{ site.title }}</title>
     {% elsif t.subtitle -%}
-    {% if page.url == "/" or page.direction == "rtl" -%}
-    <title>{{ site.title }} — {{ t.subtitle }}</title>
+      {% if page.url == "/" or page.direction == "rtl" -%}
+        <title>{{ site.title }} — {{ t.subtitle }}</title>
+      {% else -%}
+        <title>{{ t.subtitle }} — {{ site.title }}</title>
+      {% endif -%}
     {% else -%}
-    <title>{{ t.subtitle }} — {{ site.title }}</title>
-    {% endif -%}
-    {% else -%}
-    <title>{{ site.title }}</title>
+      <title>{{ site.title }}</title>
     {% endif -%}
     {% seo title=false -%}
     {% feed_meta %}
@@ -40,32 +40,32 @@ algolia:
       ga('send', 'pageview');
     </script>
     {% if site.data.locales and page.lang -%}
-    {% assign locales = site.data.locales | sort -%}
-    {% for locale in locales -%}
-      {% assign lang = locale[0] -%}
-      {% if lang == "en" -%}
-      <link rel="alternate" hreflang="en" href="{{ site.url }}" />
-      <link rel="alternate" hreflang="x-default" href="{{ site.url }}" />
-      {% else -%}
-      <link rel="alternate" hreflang="{{ lang }}" href="{{ lang | prepend: '/index_' | prepend: site.url }}" />
-      {% endif -%}
-    {% endfor -%}
+      {% assign locales = site.data.locales | sort -%}
+      {% for locale in locales -%}
+        {% assign lang = locale[0] -%}
+        {% if lang == "en" -%}
+          <link rel="alternate" hreflang="en" href="{{ site.url }}" />
+          <link rel="alternate" hreflang="x-default" href="{{ site.url }}" />
+        {% else -%}
+          <link rel="alternate" hreflang="{{ lang }}" href="{{ lang | prepend: '/index_' | prepend: site.url }}" />
+        {% endif -%}
+      {% endfor -%}
     {% endif -%}
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css"/>
   </head>
   <body onload="setupCopyables()">
     <div id="wrap">
       <div id="header"{% if page.header-class %} class="{{ page.header-class }}"{% endif %}>
-        {% if page.logo %}
-        <img alt="{{ page.title }} logo" src="{{ page.logo | relative_url }}" width="128" height="128">
+        {% if page.logo -%}
+          <img alt="{{ page.title }} logo" src="{{ page.logo | relative_url }}" width="128" height="128">
         {% elsif site.logo -%}
-        <img alt="{{ site.title }} logo" src="{{ site.logo | relative_url }}" width="128" height="128">
+          <img alt="{{ site.title }} logo" src="{{ site.logo | relative_url }}" width="128" height="128">
         {% else -%}
-        <img alt="Homebrew logo" src="{{ "/assets/img/homebrew-256x256.png" | relative_url }}" width="128" height="128">
+          <img alt="Homebrew logo" src="{{ "/assets/img/homebrew-256x256.png" | relative_url }}" width="128" height="128">
         {% endif -%}
         <h1><a href="{{ site.baseurl }}/">{{ site.title }}</a></h1>
         {% if t.subtitle -%}
-        <p id="subtitle"><strong>{{ t.subtitle }}</strong></p>
+          <p id="subtitle"><strong>{{ t.subtitle }}</strong></p>
         {% endif -%}
         <div>
           <input
@@ -78,17 +78,17 @@ algolia:
         </div>
 
         {% if page.lang -%}
-        <select id="language" onchange="loadLanguage(this.options[this.selectedIndex].value)">
-          {% for locale in locales -%}
-            {% assign lang = locale[0] -%}
-            {% assign locale_name = locale[1][lang].locale_name -%}
-            {% if page.lang == lang -%}
-            <option value="{{ lang }}" selected="selected">{{ locale_name }}</option>
-            {% else -%}
-            <option value="{{ lang }}">{{ locale_name }}</option>
-            {% endif -%}
-          {% endfor -%}
-        </select>
+          <select id="language" onchange="loadLanguage(this.options[this.selectedIndex].value)">
+            {% for locale in locales -%}
+              {% assign lang = locale[0] -%}
+              {% assign locale_name = locale[1][lang].locale_name -%}
+              {% if page.lang == lang -%}
+                <option value="{{ lang }}" selected="selected">{{ locale_name }}</option>
+              {% else -%}
+                <option value="{{ lang }}">{{ locale_name }}</option>
+              {% endif -%}
+            {% endfor -%}
+          </select>
         {% endif -%}
       </div>
 
@@ -114,11 +114,11 @@ algolia:
     <script>
       function loadLanguage(lang) {
         if (lang === {{ page.lang | jsonify }}) {
-            return;
+          return;
         } else if (lang === "en") {
-            window.location.assign("/");
+          window.location.assign("/");
         } else {
-            window.location.assign("/index_" + lang);
+          window.location.assign("/index_" + lang);
         }
       }
 
@@ -143,12 +143,13 @@ algolia:
         if (navigator.clipboard) {
           for (const element of document.getElementsByClassName("copyable")) {
             let text = element.innerText.trim();
-            if(text.startsWith("$")) {
+            if (text.startsWith("$")) {
               text = text.substr(1).trimLeft();
             }
             const button = document.createElement("button");
             button.innerHTML = "📋";
             button.setAttribute("aria-label", "Copy to clipboard");
+
             button.onclick = () => {
               navigator.clipboard.writeText(text);
               button.innerHTML = "✅";
@@ -162,7 +163,8 @@ algolia:
     <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/4.2.0/anchor.min.js"
             integrity="sha256-m1eTvwEHwmsw4+XKF7BshClVJEPwTVycveNl0CS0Mkk="
             crossorigin="anonymous"
-            onload="loadAnchors()" async></script>
+            onload="loadAnchors()"
+            async></script>
     <script src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"
             onload="loadSearch('{{ page.lang }}', '{{ page.search_site }}')" async></script>
   </body>

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -9,7 +9,9 @@ layout: base
         <h2 id="install">{{ t.pagecontent.install.install }}</h2>
         <br>
         <div class="copyable">
-          {%- highlight bash -%} /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" {%- endhighlight -%}
+{% highlight bash -%}
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+{%- endhighlight %}
         </div>
         <br>
         <br>

--- a/_posts/2016-09-21-homebrew-1.0.0.md
+++ b/_posts/2016-09-21-homebrew-1.0.0.md
@@ -4,6 +4,7 @@ author: MikeMcQuaid
 redirect_from: /2016/09/02/homebrew-1.0.0/
 redirect_from: /blog/1.0.0/
 ---
+
 Today I'm proud to announce Homebrew 1.0.0. In the seven years since Homebrew was created by [@mxcl](https://github.com/mxcl) our community has grown to [almost 6000 unique contributors](https://github.com/Homebrew/homebrew-core/graphs/contributors), a [wide-reaching third-party "tap" ecosystem](https://github.com/search?p=2&q=homebrew-&type=Repositories&utf8=✓) and [thousands of packages](https://github.com/Homebrew/homebrew-core/tree/master/Formula).
 
 We've been working hard over the last year to make some major changes to Homebrew that we've been wanting for a long time. There have been some hiccups along the way but we now have a more stable base for using and developing Homebrew in the future.

--- a/_posts/2016-11-07-homebrew-1.1.0.md
+++ b/_posts/2016-11-07-homebrew-1.1.0.md
@@ -3,12 +3,13 @@ title: 1.1.0
 author: MikeMcQuaid
 redirect_from: /blog/1.1.0/
 ---
+
 Today I'd like to announce Homebrew 1.1.0. We've had a great response to Homebrew 1.0.0 and been iterating on our work there. That 1.1.0 follows 1.0.9 is a happy coincidence due to breaking changes; in the future we may have a e.g. 1.1.10.
 
 1.1.0 contains some breaking changes:
 
 - [Disable SHA-1 checksum support in formulae](https://github.com/Homebrew/brew/pull/1451)
-- [Disable running Homebrew as the `root` user  (e.g. `sudo brew`)](https://github.com/Homebrew/brew/pull/1452)
+- [Disable running Homebrew as the `root` user (e.g. `sudo brew`)](https://github.com/Homebrew/brew/pull/1452)
 - [Bottles with `_or_later` tags no longer use `_or_later` in their filenames so the existing bottle can be reused](https://github.com/Homebrew/brew/pull/1446)
 
 Some of the changes since 1.0.0 I'd like to highlight are the following:

--- a/_posts/2017-05-01-homebrew-1.2.0.md
+++ b/_posts/2017-05-01-homebrew-1.2.0.md
@@ -3,6 +3,7 @@ title: 1.2.0
 author: MikeMcQuaid
 redirect_from: /blog/1.2.0/
 ---
+
 Today I'd like to announce Homebrew 1.2.0. The most significant change since 1.1.0 is that most Homebrew taps (package repositories) in the [Homebrew GitHub organisation](https://github.com/Homebrew) have been deprecated and the currently buildable software moved into [Homebrew/homebrew-core](https://github.com/Homebrew/homebrew-core). This will improve the quality and availability of all their software.
 
 Additionally, as Homebrew/homebrew-versions has been moved into [Homebrew/homebrew-core](https://github.com/Homebrew/homebrew-core) Homebrew provides better, official support for different versions. You can read more about this in the [dedicated versions document](https://docs.brew.sh/Versions.html). Please note our goal isn't to support all versions of all software but to provide some versions and tooling such that you can easily maintain more in your [own tap (package repository)](https://docs.brew.sh/How-to-Create-and-Maintain-a-Tap).

--- a/_posts/2017-07-31-homebrew-1.3.0.md
+++ b/_posts/2017-07-31-homebrew-1.3.0.md
@@ -3,6 +3,7 @@ title: 1.3.0
 author: MikeMcQuaid
 redirect_from: /blog/1.3.0/
 ---
+
 Today I'd like to announce Homebrew 1.3.0. The most significant change since 1.2.0 is that `brew install python` no longer installs a `python` binary without manual `PATH` additions and instead installs a `python2` binary. This avoids overriding the system `python` binary by default when installing Python as a dependency. It also paves the way to eventually have `python` be Python 3.x.
 
 Major changes and deprecations since 1.2.0:

--- a/_posts/2017-12-11-homebrew-1.4.0.md
+++ b/_posts/2017-12-11-homebrew-1.4.0.md
@@ -3,6 +3,7 @@ title: 1.4.0
 author: MikeMcQuaid
 redirect_from: /blog/1.4.0/
 ---
+
 Today I'd like to announce Homebrew 1.4.0. The most significant change since 1.3.0 is that Homebrew filters environment variables.
 
 Major changes and deprecations since 1.3.0:
@@ -14,7 +15,7 @@ Major changes and deprecations since 1.3.0:
 
 Other changes since 1.3.0 I'd like to highlight are the following:
 
-- [Xcode 9.2  is the latest supported version of Xcode](https://github.com/Homebrew/brew/pull/3542)
+- [Xcode 9.2 is the latest supported version of Xcode](https://github.com/Homebrew/brew/pull/3542)
 - [macOS High Sierra is the latest supported version of macOS](https://github.com/Homebrew/brew/pull/3121)
 - [Homebrew's vendored Ruby is 2.3.3 (the same version as provided by macOS High Sierra). This is only used on older macOS versions.](https://github.com/Homebrew/brew/pull/3164)
 - Using the [`HOMEBREW_FORCE_BREWED_CURL`](https://github.com/Homebrew/brew/pull/3533) variable you can [force Homebrew to use its own `curl`](https://github.com/Homebrew/brew/pull/3482) for all downloads. This may be useful combined with the `proxychains-ng` formula in bypassing any grating, ceramic firewalls.

--- a/_posts/2018-01-19-homebrew-1.5.0.md
+++ b/_posts/2018-01-19-homebrew-1.5.0.md
@@ -3,6 +3,7 @@ title: 1.5.0
 author: MikeMcQuaid
 redirect_from: /blog/1.5.0/
 ---
+
 Today I'd like to announce Homebrew 1.5.0. The most significant changes since 1.4.0 are deprecations of formula APIs and some Homebrew organisation formula taps.
 
 Future dates for your calendar:

--- a/_posts/2018-04-09-homebrew-1.6.0.md
+++ b/_posts/2018-04-09-homebrew-1.6.0.md
@@ -3,6 +3,7 @@ title: 1.6.0
 author: MikeMcQuaid
 redirect_from: /blog/1.6.0/
 ---
+
 Today I'd like to announce Homebrew 1.6.0. The most significant changes since 1.5.0 are `brew install python` installing Python 3, the deprecation of [Homebrew/php](https://github.com/homebrew/homebrew-php) and various formula API deprecations.
 
 Major changes and deprecations since 1.5.0:

--- a/_posts/2018-07-15-homebrew-1.7.0.md
+++ b/_posts/2018-07-15-homebrew-1.7.0.md
@@ -3,6 +3,7 @@ title: 1.7.0
 author: MikeMcQuaid
 redirect_from: /blog/1.7.0/
 ---
+
 Today I'd like to announce Homebrew 1.7.0. The most significant changes since 1.7.0 are fixes for macOS 10.14 Mojave's developer beta, [Homebrew Formulae's](https://formulae.brew.sh) JSON analytics and formulae APIs and various formula API deprecations.
 
 Major changes and deprecations since 1.6.0:

--- a/_posts/2018-10-23-homebrew-1.8.0.md
+++ b/_posts/2018-10-23-homebrew-1.8.0.md
@@ -3,6 +3,7 @@ title: 1.8.0
 author: MikeMcQuaid
 redirect_from: /blog/1.8.0/
 ---
+
 Today I'd like to announce Homebrew 1.8.0. The most significant changes since 1.7.0 are official Mojave support, linkage auto-repair on `brew upgrade`, `brew info` displaying analytics data and quarantining Cask’s downloads.
 
 Major changes and deprecations since 1.7.0:

--- a/_posts/2019-01-09-homebrew-1.9.0.md
+++ b/_posts/2019-01-09-homebrew-1.9.0.md
@@ -3,6 +3,7 @@ title: 1.9.0
 author: MikeMcQuaid
 redirect_from: /blog/1.9.0/
 ---
+
 Today I'd like to announce Homebrew 1.9.0. The most significant changes since 1.8.0 are Linux support, (optional) automatic `brew cleanup` and providing bottles (binary packages) to more Homebrew users.
 
 Major changes and deprecations since 1.8.0:

--- a/_posts/2019-02-02-homebrew-2.0.0.md
+++ b/_posts/2019-02-02-homebrew-2.0.0.md
@@ -3,6 +3,7 @@ title: 2.0.0
 author: MikeMcQuaid
 redirect_from: /blog/2.0.0/
 ---
+
 Today I'd like to announce Homebrew 2.0.0. The most significant changes since 1.9.0 are official support for Linux and Windows 10 (with Windows Subsystem for Linux), `brew cleanup` running automatically, no more options in Homebrew/homebrew-core, and removal of support for OS X Mountain Lion (10.8) and older.
 
 Major changes and deprecations since 1.9.0:

--- a/_posts/2019-04-04-homebrew-2.1.0.md
+++ b/_posts/2019-04-04-homebrew-2.1.0.md
@@ -3,6 +3,7 @@ title: 2.1.0
 author: MikeMcQuaid
 redirect_from: /blog/2.1.0/
 ---
+
 Today I'd like to announce Homebrew 2.1.0. The most significant changes since 2.0.0 are casks on <https://formulae.brew.sh>, search on Homebrew sites and better Docker support.
 
 Major changes and deprecations since 2.0.0:

--- a/_posts/2019-06-14-homebrew-maintainer-meeting.md
+++ b/_posts/2019-06-14-homebrew-maintainer-meeting.md
@@ -2,6 +2,7 @@
 title: Homebrew Maintainer Meeting
 author: MikeMcQuaid
 ---
+
 In February 2019 we had our first Homebrew maintainer in-person meeting at and around the [FOSDEM 2019 conference](https://fosdem.org/2019/) in Brussels. Maintainers travelled from as far as India and Canada in order to get face-time with each other and have high-bandwidth conversations.
 
 Maintainers arrived on Friday and met informally to socialise and get to know each other. On Saturday we released [Homebrew 2.0.0](https://brew.sh/2019/02/02/homebrew-2.0.0/) and on Saturday and Sunday attended the various talks at the conference (including a [Homebrew 2.0.0 talk](https://mikemcquaid.com/talks/homebrew-2.0.0/)).

--- a/_posts/2019-11-27-homebrew-2.2.0.md
+++ b/_posts/2019-11-27-homebrew-2.2.0.md
@@ -3,6 +3,7 @@ title: 2.2.0
 author: MikeMcQuaid
 redirect_from: /blog/2.2.0/
 ---
+
 Today I'd like to announce Homebrew 2.2.0. The most significant changes since 2.1.0 are macOS Catalina support, performance increases and better Homebrew on Linux ecosystem integration.
 
 Major changes and deprecations since 2.1.0:

--- a/_posts/2020-05-29-homebrew-2.3.0.md
+++ b/_posts/2020-05-29-homebrew-2.3.0.md
@@ -3,6 +3,7 @@ title: 2.3.0
 author: MikeMcQuaid
 redirect_from: /blog/2.3.0/
 ---
+
 Today I'd like to announce Homebrew 2.3.0. The most significant changes since 2.2.0 are GitHub Actions CI usage, fetching resources before installation, Docker image improvements and the deprecation of `brew install` from URLs.
 
 Major changes and deprecations since 2.2.0:
@@ -27,7 +28,7 @@ Other changes since 2.2.0 I'd like to highlight are the following:
 - [Formulae can use the `free_port` test helper.](https://github.com/Homebrew/brew/pull/7225)
 - [All Homebrew `curl` requests retry 2 times by default.](https://github.com/Homebrew/brew/pull/7196)
 - [Formulae `patch` blocks can change directories to apply their patch.](https://github.com/Homebrew/brew/pull/7132)
-- [`brew tap` defaults to full clones. The existing shallow clone default would cause slower `git fetch`es  over time.](https://github.com/Homebrew/brew/pull/6991)
+- [`brew tap` defaults to full clones. The existing shallow clone default would cause slower `git fetch`es over time.](https://github.com/Homebrew/brew/pull/6991)
 - [`HOMEBREW_BREW_GIT_REMOTE` and `HOMEBREW_CORE_GIT_REMOTE` environment variables allow you to use custom Git mirrors to speed up `brew update` and `brew tap`.](https://github.com/Homebrew/brew/pull/6667)
 
 Finally:

--- a/_posts/2020-06-11-homebrew-2.4.0.md
+++ b/_posts/2020-06-11-homebrew-2.4.0.md
@@ -3,6 +3,7 @@ title: 2.4.0
 author: MikeMcQuaid
 redirect_from: /blog/2.4.0/
 ---
+
 Today I'd like to announce Homebrew 2.4.0. The most significant changes since 2.3.0 are dropping macOS Mavericks support, the deprecation of `devel` versions and `brew audit` speedups.
 
 Major changes and deprecations since 2.3.0:

--- a/_posts/2020-09-08-homebrew-2.5.0.md
+++ b/_posts/2020-09-08-homebrew-2.5.0.md
@@ -3,12 +3,12 @@ title: 2.5.0
 author: MikeMcQuaid
 redirect_from: /blog/2.5.0/
 ---
+
 Today I'd like to announce Homebrew 2.5.0. The most significant changes since 2.4.0 are better `brew cask` integration, license support and API deprecations.
 
 Major changes and deprecations since 2.4.0:
 
-- Many `brew cask` [commands](https://github.com/Homebrew/brew/pull/8387) [have](https://github.com/Homebrew/brew/pull/8302) [been](https://github.com/Homebrew/brew/pull/8387)
- replaced with `brew` commands and are deprecated. This continues our goal of better integration between `brew` and `brew cask` commands.
+- Many `brew cask` [commands](https://github.com/Homebrew/brew/pull/8387) [have](https://github.com/Homebrew/brew/pull/8302) [been](https://github.com/Homebrew/brew/pull/8387) replaced with `brew` commands and are deprecated. This continues our goal of better integration between `brew` and `brew cask` commands.
 - [Most Homebrew/homebrew-core formulae have their licenses stored and audited](https://github.com/Homebrew/brew/pull/7762).
 - [`brew typecheck` provides the beginnings of Homebrew's use of Sorbet for type-checking](https://github.com/Homebrew/brew/pull/8289).
 - [Homebrew is currently experimenting with GitHub Discussions as a possible replacement for Discourse](https://github.com/Homebrew/brew/pull/8570).

--- a/_posts/2020-12-01-homebrew-2.6.0.md
+++ b/_posts/2020-12-01-homebrew-2.6.0.md
@@ -3,6 +3,7 @@ title: 2.6.0
 author: MikeMcQuaid
 redirect_from: /blog/2.6.0/
 ---
+
 Today I'd like to announce Homebrew 2.6.0. The most significant changes since 2.5.0 are macOS Big Sur support on Intel, `brew` commands replacing all `brew cask` commands, the beginnings of macOS M1/Apple Silicon/ARM support and API deprecations.
 
 Major changes and deprecations since 2.5.0:

--- a/_posts/2020-12-21-homebrew-2.7.0.md
+++ b/_posts/2020-12-21-homebrew-2.7.0.md
@@ -3,6 +3,7 @@ title: 2.7.0
 author: MikeMcQuaid
 redirect_from: /blog/2.7.0/
 ---
+
 Today I'd like to announce Homebrew 2.7.0. The most significant changes since 2.6.0 are API deprecations.
 
 Changes and deprecations since 2.6.0:

--- a/_posts/2021-02-05-homebrew-3.0.0.md
+++ b/_posts/2021-02-05-homebrew-3.0.0.md
@@ -3,6 +3,7 @@ title: 3.0.0
 author: MikeMcQuaid
 redirect_from: /blog/3.0.0/
 ---
+
 Today I'd like to announce Homebrew 3.0.0. The most significant changes since 2.7.0 are official Apple Silicon support and a new bottle format in formulae.
 
 Major changes and deprecations since 2.7.0:

--- a/_posts/2021-04-12-homebrew-3.1.0.md
+++ b/_posts/2021-04-12-homebrew-3.1.0.md
@@ -3,6 +3,7 @@ title: 3.1.0
 author: MikeMcQuaid
 redirect_from: /blog/3.1.0/
 ---
+
 Today I'd like to announce Homebrew 3.1.0. The most significant change since 3.0.0 is the migration of our bottles (binary packages) to GitHub Packages.
 
 Major changes and deprecations since 3.0.0:

--- a/_posts/2021-06-21-homebrew-3.2.0.md
+++ b/_posts/2021-06-21-homebrew-3.2.0.md
@@ -3,6 +3,7 @@ title: 3.2.0
 author: MikeMcQuaid
 redirect_from: /blog/3.2.0/
 ---
+
 Today I'd like to announce Homebrew 3.2.0. The most significant changes since 3.1.0 are `brew install` now upgrades outdated formulae by default and basic macOS 12 (Monterey) support.
 
 Major changes and deprecations since 3.1.0:

--- a/_posts/2021-10-25-homebrew-3.3.0.md
+++ b/_posts/2021-10-25-homebrew-3.3.0.md
@@ -3,6 +3,7 @@ title: 3.3.0
 author: MikeMcQuaid
 redirect_from: /blog/3.3.0/
 ---
+
 Today I'd like to announce Homebrew 3.3.0. The most significant changes since 3.2.0 are the migration from [Homebrew/linuxbrew-core](https://github.com/homebrew/linuxbrew-core) to [Homebrew/homebrew-core](https://github.com/homebrew/homebrew-core) for all Homebrew on Linux users, the official support of macOS Monterey (and, as usual, dropping the support for Mojave due to us only supporting 3 macOS versions) and the addition of an opt-in `HOMEBREW_INSTALL_FROM_API` flag to avoid needing to have Homebrew/homebrew-core or Homebrew/homebrew-cask repositories tapped/cloned locally.
 
 Major changes and deprecations since 3.2.0:

--- a/_posts/2022-02-28-homebrew-3.4.0.md
+++ b/_posts/2022-02-28-homebrew-3.4.0.md
@@ -3,6 +3,7 @@ title: 3.4.0
 author: MikeMcQuaid
 redirect_from: /blog/3.4.0/
 ---
+
 Today I'd like to announce Homebrew 3.4.0. The most significant changes since 3.3.0 are `HOMEBREW_NO_ENV_HINTS` to hide configuration suggestions, `brew services` supported on `systemd` on Linux, `brew install --overwrite` and Homebrew beginning the process to leave the SFC.
 
 Major changes and deprecations since 3.3.0:

--- a/_posts/2022-06-06-homebrew-3.5.0.md
+++ b/_posts/2022-06-06-homebrew-3.5.0.md
@@ -3,6 +3,7 @@ title: 3.5.0
 author: MikeMcQuaid
 redirect_from: /blog/3.5.0/
 ---
+
 Today I'd like to announce Homebrew 3.5.0. The most significant changes since 3.4.0 are improved `brew update` behaviour and Homebrew (on macOS) requiring at least OS X El Capitan (10.11).
 
 Major changes and deprecations since 3.4.0:

--- a/_posts/2022-09-07-homebrew-3.6.0.md
+++ b/_posts/2022-09-07-homebrew-3.6.0.md
@@ -3,6 +3,7 @@ title: 3.6.0
 author: MikeMcQuaid
 redirect_from: /blog/3.6.0/
 ---
+
 Today I'd like to announce Homebrew 3.6.0. The most significant changes since 3.5.0 are preliminary macOS Ventura support, the need for `--eval-all`/`HOMEBREW_EVAL_ALL` and a migration to Ubuntu 22.04 as our CI platform.
 
 Major changes and deprecations since 3.5.0:

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -62,6 +62,7 @@ h1, h2, h3, h4, h5, h6 {
 
 h1 {
   font-weight: 900;
+
   a, a:hover {
     font-weight: 900;
     color: $color_peach_orange_approx;
@@ -182,6 +183,7 @@ table {
   border: solid $black_40 1px;
   @include border-radius(0.4em);
   margin-top: 1em;
+
   th, td {
     padding: 0.1em 1em;
     width: auto;
@@ -226,9 +228,11 @@ div .highlight {
 .copyable {
   display: flex;
   justify-content: center;
+
   .highlight {
     overflow-x: auto;
     margin: 0;
+
     pre {
       @include border-side-radius("right", 0);
       margin: 0;
@@ -257,6 +261,7 @@ div .highlight {
 .install {
   display: flex;
   align-items: center;
+
   .label {
     padding-right: 0.4em;
   }
@@ -269,6 +274,7 @@ pre {
   padding: 8px 10px;
   @include border-radius(0.4em);
   overflow-x: auto;
+
   code {
     font-family: "Monaco", "Menlo", monospace;
     font-size: 11px;
@@ -280,6 +286,7 @@ a {
   text-decoration: none;
   color: $color_marigold_approx;
   font-weight: bold;
+
   &:focus {
     outline: 1px dotted;
     color: $color_di_serria_approx;
@@ -319,6 +326,7 @@ small {
 
 .group {
   display: block;
+
   &:after {
     content: ".";
     display: block;
@@ -409,7 +417,7 @@ button::-moz-focus-inner {
     font-size: 80%;
   }
 
-  li>p>code {
+  li > p > code {
     white-space: nowrap;
   }
 }
@@ -422,6 +430,7 @@ button::-moz-focus-inner {
 
 #information {
   border-top: 1px solid $black_50;
+
   .row {
     .col-1 {
       width: 49%;
@@ -445,9 +454,11 @@ button::-moz-focus-inner {
     text-align: center;
     color: $color_shadow_approx;
     padding-bottom: 2em;
+
     blockquote {
       font-size: 140%;
       padding: 0 15%;
+
       span {
         font-size: 140%;
         line-height: 0.5;
@@ -457,6 +468,7 @@ button::-moz-focus-inner {
 
     cite {
       font-style: normal;
+
       a {
         font-weight: normal;
       }
@@ -468,18 +480,21 @@ button::-moz-focus-inner {
     font-size: 70%;
     text-align: center;
     padding-top: 1.8em;
+
     p {
       opacity: 0.5;
       margin: 0;
       padding: 0 0 0.7em;
     }
   }
+
   .button a {
     background: $color_reno_sand_30_approx;
     padding: 8px 10px 6px;
     @include border-radius(0.4em);
     @include box-shadow(0, 0, 5px, $black_40);
     font-size: larger;
+
     &:hover {
       background: $color_reno_sand_25_approx;
     }
@@ -540,6 +555,7 @@ span .amp {
   padding: 0.1em;
   text-align: center;
   width: 25em;
+
   @media only screen and (max-width: 480px) {
     width: 12em;
   }
@@ -560,6 +576,7 @@ span .amp {
     .col-1 {
       float: right;
     }
+
     .col-2 {
       float: left;
     }

--- a/blog/index.html
+++ b/blog/index.html
@@ -2,20 +2,19 @@
 title: Homebrew
 layout: base
 ---
+
 <ul class="posts">
-{% for post in site.posts -%}
-  <li>
-    <a href="{{ post.url }}" title="{{ post.title }}">
-      <h2>
-        {{ post.title }}
-      </h2>
-      <h3>{{ post.date | date_to_string }}</h3>
-    </a>
-    <div class="postcontent">{{ post.excerpt }}</div>
-    <br/>
-    <div class="clearboth"></div>
-  </li>
-{% endfor -%}
+  {% for post in site.posts -%}
+    <li>
+      <a href="{{ post.url }}" title="{{ post.title }}">
+        <h2>{{ post.title }}</h2>
+        <h3>{{ post.date | date_to_string }}</h3>
+      </a>
+      <div class="postcontent">{{ post.excerpt }}</div>
+      <br/>
+      <div class="clearboth"></div>
+    </li>
+  {% endfor -%}
 </ul>
 
 {%- include newsletter.html -%}


### PR DESCRIPTION
This PR contains various whitespace-related tweaks:

* Per our discussion in #918, I've modified the indentation around Liquid tags like `if`/`else`/`for`/etc., so the code can be more easily understood by making the nesting apparent. The generated HTML isn't as nice but we agreed that the readability of the template was more important.
* In the JavaScript, I standardized indentation and added spaces and blank lines where appropriate.
* In `_layouts/index.html`, I modified the formatting for the initial `copyable` `highlight` to use the same style as the other code blocks (for consistency/readability).
* In the post Markdown, I standardized spaces in copy, added a blank line after the front matter, and removed a stray line break.
* In `/assets/css/style.css`, I added blank lines between declarations and selectors and added spaces to a selector with direct descendants (i.e., `li>p>code` -> `li > p > code`).

I can split this into more topical commits, if needed (or if it would help with review).

It's worth noting that this includes changes from #918, so we'll want to merge that first but this should cleanly rebase afterward (or maybe not).