### PR TITLE
Adjust Markdown link syntax

### DIFF
--- a/_posts/2022-09-07-homebrew-3.6.0.md
+++ b/_posts/2022-09-07-homebrew-3.6.0.md
@@ -16,7 +16,7 @@ Major changes and deprecations since 3.5.0:
 
 Other changes since 3.5.0 I'd like to highlight are the following:
 
-- `HOMEBREW_INSTALL_FROM_API` is an opt-in flag added in 3.3.0 to install formulae and casks in homebrew/core and homebrew/cask taps using Homebrew's API instead of needing the (large, slow) local checkouts of these repositories. `HOMEBREW_INSTALL_FROM_API` has had [many](<https://github.com/Homebrew/brew/pull/13439>) [improvements](https://github.com/Homebrew/brew/pull/13440) since 3.5.0. We encourage you to try setting it and [reporting any issues](https://github.com/Homebrew/brew/issues/new/choose) you experience.
+- `HOMEBREW_INSTALL_FROM_API` is an opt-in flag added in 3.3.0 to install formulae and casks in homebrew/core and homebrew/cask taps using Homebrew's API instead of needing the (large, slow) local checkouts of these repositories. `HOMEBREW_INSTALL_FROM_API` has had [many](https://github.com/Homebrew/brew/pull/13439) [improvements](https://github.com/Homebrew/brew/pull/13440) since 3.5.0. We encourage you to try setting it and [reporting any issues](https://github.com/Homebrew/brew/issues/new/choose) you experience.
 - [The `postgresql` formula was renamed to `postgresql@14` to avoid repeated breakage on major/minor version upgrades.](https://github.com/Homebrew/homebrew-core/pull/107726)
 - [`HOMEBREW_CURL_PATH` and `HOMEBREW_GIT_PATH` are documented and supported for setting the location of `curl` or `git` on Linux. On macOS, the system versions will still always be used instead.](https://github.com/Homebrew/brew/pull/13423)
 - [`HOMEBREW_ARTIFACT_DOMAIN` only takes effect on bottles and not e.g. casks.](https://github.com/Homebrew/brew/pull/13258)


### PR DESCRIPTION
This is a one-off tweak for a Markdown link that unnecessarily includes angle brackets around a URL using `[text](link)` syntax.