### PR TITLE
Remove empty attributes

### DIFF
--- a/_includes/newsletter.html
+++ b/_includes/newsletter.html
@@ -5,12 +5,12 @@
     <label for="newsletter-email">Subscribe to be notified about new posts</label>
   </h3>
   <p>
-    <input id="newsletter-email" type="email" name="EMAIL" value="" minlength="6">
+    <input id="newsletter-email" type="email" name="EMAIL" minlength="6">
   </p>
 
   <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
   <div style="position: absolute; left: -5000px;" aria-hidden="true">
-    <input type="text" name="b_d167156eb854fd2b002d85938_8b2424147f" tabindex="-1" value="">
+    <input type="text" name="b_d167156eb854fd2b002d85938_8b2424147f" tabindex="-1">
   </div>
 
   <input id="newsletter-submit" type="submit" name="subscribe" value="Subscribe" />

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -55,8 +55,8 @@ algolia:
   </head>
   <body onload="setupCopyables()">
     <div id="wrap">
-      <div id="header" class="{{ page.header-class }}">
-        {% if page.logo -%}
+      <div id="header"{% if page.header-class %} class="{{ page.header-class }}"{% endif %}>
+        {% if page.logo %}
         <img alt="{{ page.title }} logo" src="{{ page.logo | relative_url }}" width="128" height="128">
         {% elsif site.logo -%}
         <img alt="{{ site.title }} logo" src="{{ site.logo | relative_url }}" width="128" height="128">


### PR DESCRIPTION
This PR adds Liquid tags to conditionally include a `class` attribute on an element in `base.html`, so that we don't end up with `class=""` when `page.header-class` isn't available.

This also removes empty attributes (i.e., `value=""`) from a couple of elements in `newsletter.html`, assuming there's not a technical reason for their inclusion that I'm overlooking.