### PR TITLE
Remove trailing forward slash from void elements

### DIFF
--- a/_includes/newsletter.html
+++ b/_includes/newsletter.html
@@ -13,5 +13,5 @@
     <input type="text" name="b_d167156eb854fd2b002d85938_8b2424147f" tabindex="-1">
   </div>
 
-  <input id="newsletter-submit" type="submit" name="subscribe" value="Subscribe" />
+  <input id="newsletter-submit" type="submit" name="subscribe" value="Subscribe">
 </form>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -9,7 +9,7 @@ algolia:
 <!DOCTYPE html>
 <html {% if page.direction == "rtl" %}dir="rtl" {% endif %}lang="{{ page.lang | default: "en" }}">
   <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     {% if page.title -%}
       <title>{{ page.title }} — {{ site.title }}</title>
     {% elsif t.subtitle -%}
@@ -27,7 +27,7 @@ algolia:
     <link rel="icon" type="image/x-icon" href="{{ "/assets/img/favicon.ico" | relative_url }}">
     <link rel="apple-touch-icon" href="{{ "/assets/img/apple-touch-icon.png" | relative_url }}">
     <link rel="stylesheet" href="{{ "/assets/css/style.css" | relative_url }}" type="text/css" media="screen">
-    <link rel="preconnect" href="https://{{ layout.algolia.appId }}-dsn.algolia.net" crossorigin />
+    <link rel="preconnect" href="https://{{ layout.algolia.appId }}-dsn.algolia.net" crossorigin>
     {% if site.url == "http://localhost:4000" -%}
       <script src="https://cdn.jsdelivr.net/npm/@khanacademy/tota11y/dist/tota11y.min.js" crossorigin="anonymous" async></script>
     {% endif -%}
@@ -46,17 +46,17 @@ algolia:
       {% for locale in locales -%}
         {% assign lang = locale[0] -%}
         {% if lang == "en" -%}
-          <link rel="alternate" hreflang="en" href="{{ site.url }}" />
-          <link rel="alternate" hreflang="x-default" href="{{ site.url }}" />
+          <link rel="alternate" hreflang="en" href="{{ site.url }}">
+          <link rel="alternate" hreflang="x-default" href="{{ site.url }}">
         {% else -%}
-          <link rel="alternate" hreflang="{{ lang }}" href="{{ lang | prepend: '/index_' | prepend: site.url }}" />
+          <link rel="alternate" hreflang="{{ lang }}" href="{{ lang | prepend: '/index_' | prepend: site.url }}">
         {% endif -%}
       {% endfor -%}
     {% endif -%}
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3/dist/style.min.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3/dist/style.min.css">
     {% if page.url == "/" -%}
       {% for rel_me_url in site.link_rel_me_urls -%}
-        <link href="{{rel_me_url}}" rel="me" />
+        <link href="{{rel_me_url}}" rel="me">
       {% endfor -%}
     {% endif -%}
   </head>

--- a/blog/index.html
+++ b/blog/index.html
@@ -11,7 +11,7 @@ layout: base
         <h3>{{ post.date | date_to_string }}</h3>
       </a>
       <div class="postcontent">{{ post.excerpt }}</div>
-      <br/>
+      <br>
       <div class="clearboth"></div>
     </li>
   {% endfor -%}


### PR DESCRIPTION
It's not necessary to self-close a void element in HTML5 and this is the cause of a lot of validation noise for us (unless restricted to only errors). We currently have void elements that use a trailing forward slash and some that don't, so this PR removes the forward slash from related elements.

Unfortunately, our generated HTML will continue to include trailing forward slashes in void elements from the `jekyll-feed` and `jekyll-seo-tag` gems (where we can't control the output) but we can at least address this in our templates.

This is based on #918 and #919 (including changes from both), so it will need to be merged after those PRs but it should cleanly rebase after #919.