### PR TITLE
Update versioned JavaScript libraries

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -29,7 +29,7 @@ algolia:
     <link rel="stylesheet" href="{{ "/assets/css/style.css" | relative_url }}" type="text/css" media="screen">
     <link rel="preconnect" href="https://{{ layout.algolia.appId }}-dsn.algolia.net" crossorigin />
     {% if site.url == "http://localhost:4000" -%}
-    <script src="https://github.com/Khan/tota11y/releases/download/0.1.3/tota11y.min.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/@khanacademy/tota11y/dist/tota11y.min.js" crossorigin="anonymous" async></script>
     {% endif -%}
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -163,8 +163,8 @@ algolia:
         setupCopyables();
       });
     </script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/4.2.0/anchor.min.js"
-            integrity="sha256-m1eTvwEHwmsw4+XKF7BshClVJEPwTVycveNl0CS0Mkk="
+    <script src="https://cdn.jsdelivr.net/npm/anchor-js@5.0.0/anchor.min.js"
+            integrity="sha256-aQmOEF2ZD4NM/xt4hthzREIo/2PFkOX/g01WjxEV7Ys="
             crossorigin="anonymous"
             onload="loadAnchors()"
             async></script>


### PR DESCRIPTION
This PR updates versioned JavaScript libraries in `script` elements (`tota11y`, `anchor-js`) in addition to the following changes:

* Use `cdn.jsdelivr.net` where a specific source isn't required. Minimizing the number of remote sources will cut down on DNS lookups, which doesn't hurt. [If we would prefer to use a different CDN, I can revise this.]
* ~Move `tota11y` from the `head` to the end of the `body` (i.e., I don't see a technical reason why `tota11y` should be loaded in the head).~
* Unversion `tota11y`, since it's only loaded in a local development environment (i.e., any breaking changes won't affect the public site if/when a new version is released).