### PR TITLE
Standardize quotation marks in CSS/JS

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -115,10 +115,10 @@ algolia:
       function loadLanguage(lang) {
         if (lang === {{ page.lang | jsonify }}) {
           return;
-        } else if (lang === "en") {
-          window.location.assign("/");
+        } else if (lang === 'en') {
+          window.location.assign('/');
         } else {
-          window.location.assign("/index_" + lang);
+          window.location.assign('/index_' + lang);
         }
       }
 
@@ -135,25 +135,25 @@ algolia:
           { algoliaOptions: { facetFilters: ['site: ' + site] } },
           {{ layout.algolia | jsonify }}
         ));
-        window.location.hash || document.querySelector("#search-bar").focus();
-        document.querySelector("#search-bar").value = new URLSearchParams(window.location.search).get('search');
+        window.location.hash || document.querySelector('#search-bar').focus();
+        document.querySelector('#search-bar').value = new URLSearchParams(window.location.search).get('search');
       };
 
       function setupCopyables() {
         if (navigator.clipboard) {
-          for (const element of document.getElementsByClassName("copyable")) {
+          for (const element of document.getElementsByClassName('copyable')) {
             let text = element.innerText.trim();
-            if (text.startsWith("$")) {
+            if (text.startsWith('$')) {
               text = text.substr(1).trimLeft();
             }
-            const button = document.createElement("button");
-            button.innerHTML = "📋";
-            button.setAttribute("aria-label", "Copy to clipboard");
 
+            const button = document.createElement('button');
+            button.innerHTML = '📋';
+            button.setAttribute('aria-label', 'Copy to clipboard');
             button.onclick = () => {
               navigator.clipboard.writeText(text);
-              button.innerHTML = "✅";
-              setTimeout(() => button.innerHTML="📋", 1000);
+              button.innerHTML = '✅';
+              setTimeout(() => button.innerHTML='📋', 1000);
             }
             element.appendChild(button);
           }

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -105,13 +105,13 @@ h3 {
   }
 
   h2.disabled::before, a.disabled::before {
-    content: '\26d4';
+    content: "\26d4";
     font-family: "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
     margin-right: 0.3em;
   }
 
   h2.deprecated::before, a.deprecated::before {
-    content: '\26a0';
+    content: "\26a0";
     font-family: "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
     margin-right: 0.3em;
   }
@@ -241,7 +241,7 @@ div .highlight {
     code::before {
       @extend .nv;
       display: inline;
-      content: '$ ';
+      content: "$ ";
     }
   }
 
@@ -312,7 +312,7 @@ button, input, select, textarea, option {
   font-size: 100%;
 }
 
-a, a *, button, button *, select, option, label, input[type=submit] {
+a, a *, button, button *, select, option, label, input[type="submit"] {
   cursor: pointer;
 }
 


### PR DESCRIPTION
This PR standardizes quotation marks to double quotes (`"`) in CSS and single quotes (`'`) in JavaScript. This also adds missing quotes around the attribute value of a CSS selector (i.e., `input[type=submit]` -> `input[type="submit"]`).

This includes some whitespace changes from #919 and will need to be rebased when that PR is merged.