### PR TITLE
Use SVG Homebrew logo for header

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,7 +32,7 @@ defaults:
     values:
       image: /assets/img/homebrew-social-card.png
 
-logo: /assets/img/homebrew-256x256.png
+logo: /assets/img/homebrew.svg
 
 github:
   repository_nwo: Homebrew/brew.sh

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -68,7 +68,7 @@ algolia:
         {% elsif site.logo -%}
           <img alt="{{ site.title }} logo" src="{{ site.logo | relative_url }}" width="128" height="128">
         {% else -%}
-          <img alt="Homebrew logo" src="{{ "/assets/img/homebrew-256x256.png" | relative_url }}" width="128" height="128">
+          <img alt="Homebrew logo" src="{{ "/assets/img/homebrew.svg" | relative_url }}" width="128" height="128">
         {% endif -%}
         <h1><a href="{{ site.baseurl }}/">{{ site.title }}</a></h1>
         {% if t.subtitle -%}


### PR DESCRIPTION
This reduces the page load size for this element from ~15 KiB to ~4.3 KiB, saving around 10 KiB or reducing the total page load size by around 11% as of the currently deployed master as reported by [this GTMetrix report](https://gtmetrix.com/reports/brew.sh/qADTEmpE/).

The homebrew-256x256.png remains in the repo in case it's been deeplinked somewhere but this header was its only usage in the codebase.

There's no noticeable visual difference between the two, but for me on my Chromebook with Chrome 109 on a high-res screen, it's simply crisper.
