### PR TITLE
Shave some time by setting up copyables asynchronously

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -60,7 +60,7 @@ algolia:
       {% endfor -%}
     {% endif -%}
   </head>
-  <body onload="setupCopyables()">
+  <body>
     <div id="wrap">
       <div id="header"{% if page.header-class %} class="{{ page.header-class }}"{% endif %}>
         {% if page.logo -%}
@@ -138,7 +138,7 @@ algolia:
         ));
       };
 
-      function setupCopyables() {
+      async function setupCopyables() {
         if (navigator.clipboard) {
           for (const element of document.getElementsByClassName('copyable')) {
             let text = element.innerText.trim();
@@ -158,6 +158,10 @@ algolia:
           }
         }
       }
+
+      window.addEventListener("DOMContentLoaded", function() {
+        setupCopyables();
+      });
     </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/4.2.0/anchor.min.js"
             integrity="sha256-m1eTvwEHwmsw4+XKF7BshClVJEPwTVycveNl0CS0Mkk="
@@ -165,7 +169,7 @@ algolia:
             onload="loadAnchors()"
             async></script>
     <script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3/dist/umd/index.min.js"
-            onload="loadSearch('{{ page.lang }}', '{{ page.search_site }}')" 
+            onload="loadSearch('{{ page.lang }}', '{{ page.search_site }}')"
             async></script>
   </body>
 </html>


### PR DESCRIPTION
GTMetrix reported a main thread block of 106 ms in [this report](https://gtmetrix.com/reports/brew.sh/xEffK6jK/) because of the copyables running synchronously. There's no reason to do that in an age when all browsers we care about support async. So, we catch the DOMContentLoaded and dumbfire the setup.
