### PR TITLE
Drops the hardcoded installation prefix from the explanations

### DIFF
--- a/_data/locales/en.yml
+++ b/_data/locales/en.yml
@@ -5,7 +5,7 @@ en:
     search: Search
     question: What Does Homebrew Do?
     what: Homebrew installs <a href="https://formulae.brew.sh/formula/" title="List of Homebrew packages">the stuff you need</a> that Apple (or your Linux system) didn’t.
-    how: Homebrew installs packages to their own directory and then symlinks their files into <code>/usr/local</code> (on macOS Intel).
+    how: Homebrew installs packages to their own directory and then symlinks their files into the Homebrew installation prefix.
     prefix: Homebrew won’t install files outside its prefix and you can place a Homebrew installation wherever you like.
     createpackages: Trivially create your own Homebrew packages.
     hack: It’s all Git and Ruby underneath, so hack away with the knowledge that you can easily revert your modifications and merge upstream updates.


### PR DESCRIPTION
This will require updates to the other localizations...

Work toward #933
