### PR TITLE
Drop Google Analytics

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -31,16 +31,6 @@ algolia:
     {% if site.url == "http://localhost:4000" -%}
     <script src="https://github.com/Khan/tota11y/releases/download/0.1.3/tota11y.min.js"></script>
     {% endif -%}
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-      ga('create', 'UA-76679469-2', 'auto');
-      ga('set', 'anonymizeIp', true);
-      ga('send', 'pageview');
-    </script>
     {% if site.data.locales and page.lang -%}
       {% assign locales = site.data.locales | sort -%}
       {% for locale in locales -%}


### PR DESCRIPTION
It's huge and the stats we get from GitHub Pages are sufficient apparently, per
@MikeMcQuaid.
