### PR TITLE
2023-02-16-homebrew-4.0.0: tweak InfluxDB description.

### DIFF
--- a/_posts/2023-02-16-homebrew-4.0.0.md
+++ b/_posts/2023-02-16-homebrew-4.0.0.md
@@ -17,10 +17,10 @@ Major changes and deprecations since 3.6.0:
   - If you wish to opt-out of this behaviour change, you can [`export HOMEBREW_NO_INSTALL_FROM_API=1`](https://github.com/Homebrew/brew/pull/14375). Please investigate [`HOMEBREW_API_AUTO_UPDATE_SECS`](https://github.com/Homebrew/brew/pull/14589) first.
   - This behaviour is automatically disabled when using [certain commands](https://github.com/Homebrew/brew/pull/14524) or in configurations that [mostly build from source](https://github.com/Homebrew/brew/pull/14480).
   - [`HOMEBREW_API_DOMAIN` can be set to use mirrors for](https://github.com/Homebrew/brew/pull/14494) [formulae.brew.sh](https://formulae.brew.sh).
-- Homebrew's analytics are now sent both to Google Analytics and our new, self-hosted InfluxDB instance hosted in the EU.
-  - Our self-hosted InfluxDB instance does not store either anonymised IP addresses or an anonymised user token so it has additional privacy benefits over Google Analytics.
+- Homebrew's analytics are now sent both to Google Analytics and our new InfluxDB instance hosted in the EU.
+  - Our InfluxDB instance does not store either anonymised IP addresses or an anonymised user token so it has additional privacy benefits over Google Analytics.
   - If you had previously set `HOMEBREW_NO_ANALYTICS` because you didn't like Google Analytics and/or data being sent to the USA: please consider unsetting this and setting `HOMEBREW_NO_GOOGLE_ANALYTICS` instead, allowing analytics data to be sent to our new InfluxDB host.
-  - We expect to migrate entirely from Google Analytics to our self-hosted InfluxDB instance in ~90 days at which point we will remove all Google Analytics and destroy all existing data.
+  - We expect to migrate entirely from Google Analytics to our InfluxDB instance in ~100 days at which point we will remove all Google Analytics and destroy all existing data.
 - [macOS `.pkg` files are generated for each Homebrew release](https://github.com/Homebrew/brew/pull/14265). You can help us test this beta feature by [downloading the generated package artifact from the relevant GitHub Actions release events](https://github.com/Homebrew/brew/actions/workflows/build-pkg.yml?query=event%3Arelease).
 - [The `homebrew/ubuntu16.04:master` image has been deprecated](https://github.com/Homebrew/brew/pull/13819).
 - [Various major release deprecations and disables](https://github.com/Homebrew/brew/pull/14382).


### PR DESCRIPTION
It's not technically self-hosted, I got this wrong.