### PR TITLE
Set specific version of Algolia docsearch, set SRI

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -160,7 +160,9 @@ algolia:
             crossorigin="anonymous"
             onload="loadAnchors()"
             async></script>
-    <script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3/dist/umd/index.min.js"
+    <script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3.5.2/dist/umd/index.js"
+            integrity="sha256-Y1WAhww0aFm/7xcgnD56E3jWSfKlRG9DIB2Tcs8exCQ="
+            crossorigin="anonymous"
             onload="loadSearch('{{ page.lang }}', '{{ page.search_site }}')"
             async></script>
   </body>


### PR DESCRIPTION
I was about to drop the SRI attributes, but then noticed that jsdelivr had some warnings:

* Skipped minification because the original files appear to be already minified.
* Original file: /npm/@docsearch/js@3.5.2/dist/umd/index.js
* Do NOT use SRI with dynamically generated files! More information: https://www.jsdelivr.com/using-sri-with-dynamic-files

So, to heed these warnings, I decided it was best to pin to a particular version of docsearch and use the pre-minified index.js to avoid dynamic modification.

Work toward #973