### PR TITLE
Implement a thorough Content Security Policy in meta

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -9,6 +9,24 @@ algolia:
 <!DOCTYPE html>
 <html {% if page.direction == "rtl" %}dir="rtl" {% endif %}lang="{{ page.lang | default: "en" }}">
   <head>
+    <meta http-equiv="Content-Security-Policy"
+          content="default-src 'none';
+                    connect-src https://{{ layout.algolia.appId }}-dsn.algolia.net;
+                    font-src https://fonts.gstatic.com;
+                    img-src 'self' https://avatars2.githubusercontent.com https://avatars.githubusercontent.com;
+                    object-src 'none';
+                    {% comment %}
+                      We could remove the 'unsafe-inline' by externalizing
+                      the JavaScript and the end of the page.
+                    {% endcomment %}
+                    script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net {%if site.url == "http://localhost:4000" %}'unsafe-eval'{%endif%};
+                    style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net;
+                    {%comment%}
+                      This is a nice to have but requires changes in
+                      libraries we use. We can periodically enable this
+                      after updating libraries to see if they support it.
+                    {%endcomment%}
+                    {%comment%}require-trusted-types-for 'script';{%endcomment%}">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     {% if page.title -%}
       <title>{{ page.title }} — {{ site.title }}</title>
@@ -130,6 +148,23 @@ algolia:
         ));
       };
 
+      {% comment %}
+      This exists to slowly enable us to use the trustedTypes
+      interface to set innerHTML. It's a part of the CSP strategy.
+      {% endcomment %}
+
+      let escapeHTML = (identity) => identity;
+
+      if (window.trustedTypes && window.trustedTypes.createPolicy) {
+        let policy = trustedTypes.createPolicy(
+          "forceInner",
+          {
+            createHTML: (to_escape) => to_escape
+          }
+        );
+        escapeHTML = (html) => policy.createHTML(html);
+      };
+
       async function setupCopyables() {
         if (navigator.clipboard) {
           for (const element of document.getElementsByClassName('copyable')) {
@@ -138,13 +173,14 @@ algolia:
               text = text.substr(1).trimLeft();
             }
 
+
             const button = document.createElement('button');
-            button.innerHTML = '📋';
+            button.innerHTML = escapeHTML('📋');
             button.setAttribute('aria-label', 'Copy to clipboard');
             button.onclick = () => {
               navigator.clipboard.writeText(text);
-              button.innerHTML = '✅';
-              setTimeout(() => button.innerHTML='📋', 1000);
+              button.innerHTML = escapeHTML('✅');
+              setTimeout(() => button.innerHTML=escapeHTML('📋'), 1000);
             }
             element.appendChild(button);
           }


### PR DESCRIPTION
OK, this time, I tested it instead of relying on the docs to be clear and accurate like I did for #975 (and suggested what I've ~used in here), necessitating the revert in #979.

I tested it by running `jekyll serve --watch` and using `ngrok HTTP 4000` to get an HTTPS URL to try loading it using TLS. I tested:

1. Algolia search box functionality
2. Clipboard click functionality
3. Language switch functionality (checked with "een beetje Nederlands" and double checked the other items)
4. Paging through many blog posts, but not all

I ensured that there were no console errors while paging around the site.

Mozilla Observatory still dings us for using `unsafe-inline` and there are other CSP-related things we can add, e.g. `base-uri` and `form-action`, which I'll address in future work.

An eventual casualty of this may be the tota11y integration used in local dev, which might be OK because [tota11y is deprecated and EOL since May 2023](https://github.com/Khan/tota11y#deprecation-notice) with a pointer to [Axe](https://www.deque.com/axe/) or to use browsers' built-in a11y tooling which has apparently improved significantly since tota11y came into existence (and @MikeMcQuaid added it six years ago in 3a0c288ffacf208b9d09b6c52fe4fe72a15b3c9f).
I've left it in a working state for now but the workaround is obvious.

