### PR TITLE
Fixes for anchor-js

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -134,7 +134,7 @@ algolia:
       function loadAnchors() {
         anchors.options = {
           placement: 'left',
-          visible: 'touch',
+          visible: 'hover',
         };
         anchors.add('#page > h2, #page > h3, #page > h4, #page > h5, #page > h6');
       };

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -12,7 +12,7 @@ algolia:
     <meta http-equiv="Content-Security-Policy"
           content="default-src 'none';
                     connect-src https://{{ layout.algolia.appId }}-dsn.algolia.net;
-                    font-src https://fonts.gstatic.com;
+                    font-src data: https://fonts.gstatic.com;
                     img-src 'self' https://avatars2.githubusercontent.com https://avatars.githubusercontent.com;
                     object-src 'none';
                     {% comment %}


### PR DESCRIPTION
1) allow loading fonts via data URLs to the CSP, which is how anchor-js supplies its default link icon; fixes missing hover link icons on docs.brew.sh
2) set the anchor-js visible value to 'hover' since ['touch' was removed for v5](https://github.com/bryanbraun/anchorjs/releases/tag/5.0.0)