### PR TITLE
Add label for language select

### DIFF
--- a/_data/locales/ar.yml
+++ b/_data/locales/ar.yml
@@ -3,6 +3,7 @@ ar:
   subtitle: مدير الحزم الذي يفتقده macOS (أو Linux)
   pagecontent:
     search: بحث
+    language: لغة
     question: ماذا يفعل Homebrew؟
     what: يثبّت Homebrew <a href="https://formulae.brew.sh/formula/" title="List of Homebrew packages">حزم انت بحاجتها</a>، Apple (أو أنظمت Linux) لم تقم بتوفيرها.
     how: يثبّت Homebrew الحزم في مجلداتها الخاصة ثم يعمل اختصارات "symlinks" لملفاتها في <code>/opt/homebrew</code>.

--- a/_data/locales/az.yml
+++ b/_data/locales/az.yml
@@ -3,6 +3,7 @@ az:
   subtitle: Çatışmayan macOS paket meneceri
   pagecontent:
     search: Search
+    language: Dil
     question: Homebrew nə edir?
     what: Homebrew Apple-nin yaza bilmədiyi <a href="https://formulae.brew.sh/formula/" title="Homebrew paketlərinin siyahısı">sizə lazım olan paketləri</a> yükləyir.
     how: Homebrew paketləri öz qovluqlarına yazır və sonra onları <code>/opt/homebrew</code>-a yönləndirir.

--- a/_data/locales/be.yml
+++ b/_data/locales/be.yml
@@ -3,6 +3,7 @@ be:
   subtitle: Менеджэр пакетаў для macOS
   pagecontent:
     search: Пошук
+    language: мова
     question: Навошта патрэбен Homebrew?
     what: Homebrew ўсталёўвае <a href="https://formulae.brew.sh/formula/" title="Спіс пакетаў Homebrew">патрэбныя вам пакеты</a>, якія Apple не прадаставіў.
     how: Homebrew ўсталёўвае праграмы ў іх уласныя дырэкторыі ды стварае сімвальныя спасылкі на іх у <code>/opt/homebrew</code>.

--- a/_data/locales/bg.yml
+++ b/_data/locales/bg.yml
@@ -3,6 +3,7 @@ bg:
   subtitle: Мениджър на пакети за macOS
   pagecontent:
     search: Search
+    language: език
     question: Какво представлява Homebrew?
     what: Homebrew инсталира <a href="https://formulae.brew.sh/formula/" title="Списък с пакети за Homebrew">всичко необходимо</a>, което Apple не може.
     how: Homebrew инсталира пакетите в неговата директория и след това създава линкове към техните файлове в <code>/opt/homebrew</code>.

--- a/_data/locales/ca.yml
+++ b/_data/locales/ca.yml
@@ -3,6 +3,7 @@ ca:
   subtitle: El gestor de paquets per macOS que faltava
   pagecontent:
     search: Search
+    language: Idioma
     question: What Does Homebrew Do?
     what: Homebrew instal·la <a href="https://formulae.brew.sh/formula/" title="Llista de paquets Homebrew">tot allò que necessites</a> que Apple no trobava necessari.
     how: Homebrew instal·la paquets al seu propi directori i després fa un <i>symlink</i> dels seus arxius a <code>/opt/homebrew</code>.

--- a/_data/locales/cs.yml
+++ b/_data/locales/cs.yml
@@ -3,6 +3,7 @@ cs:
   subtitle: Chybějící správce balíků pro macOS
   pagecontent:
     search: Search
+    language: Jazyk
     question: Co Homebrew dělá?
     what: Homebrew instaluje <a href="https://formulae.brew.sh/formula/" title="Seznam Homebrew balíků">to, co potřebujete</a> a co Apple nenainstaloval.
     how: Homebrew instaluje balíky do jejich vlastní složky a poté vytváří symbolické odkazy do <code>/opt/homebrew</code>.

--- a/_data/locales/da.yml
+++ b/_data/locales/da.yml
@@ -3,6 +3,7 @@ da:
   subtitle: macOS’s manglende pakkemanager
   pagecontent:
     search: Search
+    language: Sprog
     question: What Does Homebrew Do?
     what: Homebrew installerer <a href="https://formulae.brew.sh/formula/" title="Liste over Homebrew-pakker">alt det du har brug for</a> som Apple ikke gjorde.
     how: Homebrew installerer pakker i deres egne mapper for så at symlinke deres filer ind i <code>/opt/homebrew</code>.

--- a/_data/locales/de.yml
+++ b/_data/locales/de.yml
@@ -3,6 +3,7 @@ de:
   subtitle: Der fehlende Paketmanager für macOS (oder Linux)
   pagecontent:
     search: Suchen
+    language: Sprache
     question: Was macht Homebrew?
     what: Homebrew installiert <a href="https://formulae.brew.sh/formula/" title="Liste der Homebrew-Pakete">Zeug, das du brauchst</a>, das Apple aber nicht mitliefert.
     how: Homebrew installiert Pakete in ihrem eigenen Verzeichnis und erstellt Symlinks zu ihren Dateien in <code>/opt/homebrew</code>.

--- a/_data/locales/el.yml
+++ b/_data/locales/el.yml
@@ -3,6 +3,7 @@ el:
   subtitle: Το Πρόγραμμα Διαχείρισης Εφαρμογών που έλειπε από το macOS (ή και το Linux)
   pagecontent:
     search: Αναζήτηση
+    language: Γλώσσα
     question: Τι είναι ακριβώς και τι κάνει το Homebrew?
     what: Το Homebrew εγκαθιστά <a href="https://formulae.brew.sh/formula/" title="List of Homebrew packages">ότι χρειάζεστε</a> που το macOS (ή Linux system) δεν έχει προεγκατεστημένο.
     how: Το Homebrew εγκαθιστά τις εφαρμογές στον δικό του φάκελο και στη συνέχεια συνδέει τα αρχεία τους με το <code>/opt/homebrew</code>.

--- a/_data/locales/en.yml
+++ b/_data/locales/en.yml
@@ -3,6 +3,7 @@ en:
   subtitle: The Missing Package Manager for macOS (or Linux)
   pagecontent:
     search: Search
+    language: Language
     question: What Does Homebrew Do?
     what: Homebrew installs <a href="https://formulae.brew.sh/formula/" title="List of Homebrew packages">the stuff you need</a> that Apple (or your Linux system) didn’t.
     how: Homebrew installs packages to their own directory and then symlinks their files into <code>/opt/homebrew</code> (on Apple Silicon).

--- a/_data/locales/es.yml
+++ b/_data/locales/es.yml
@@ -3,6 +3,7 @@ es:
   subtitle: El gestor de paquetes para macOS (o Linux) que faltaba
   pagecontent:
     search: Búsqueda
+    language: Idioma
     question: ¿Qué hace Homebrew?
     what: Homebrew instala <a href="https://formulae.brew.sh/formula/" title="Lista de paquetes de Homebrew">todo aquello que necesitas</a> que Apple (o tu sistema Linux) no instala de serie.
     how: Homebrew instala cada paquete en su propio directorio, creando enlaces simbólicos a tus archivos dentro de <code>/opt/homebrew</code> (en Apple Silicon).

--- a/_data/locales/fa.yml
+++ b/_data/locales/fa.yml
@@ -3,6 +3,7 @@ fa:
   subtitle: مدیریت بسته‌های ناموجود برای macOS
   pagecontent:
     search: Search
+    language: زبان
     question: Homebrew چه کاری انجام می‌دهد؟
     what: Homebrew <a href="https://formulae.brew.sh/formula/" title="فهرست ابزارهای Homebrew">چیزهایی که شما نیاز دارید</a> و Apple ندارد را نصب می‌کند.
     how: Homebrew بسته‌ها را در ‍دایرکتوری خودشان نصب می‌کند و سپس فایل‌ها را در داخل <code>/opt/homebrew</code> مرتبط (symlinks) می‌کند.

--- a/_data/locales/fi.yml
+++ b/_data/locales/fi.yml
@@ -3,6 +3,7 @@ fi:
   subtitle: MacOS:n puuttuva pakettienhallintaohjelmisto
   pagecontent:
     search: Search
+    language: Kieli
     question: Mitä Homebrew tekee?
     what: Homebrew asentaa <a href="https://formulae.brew.sh/formula/" title="List of Homebrew packages">kaiken</a> tarvittavan, mitä Apple ei ole toimittanut itse.
     how: Homebrew asentaa paketit omiin kansioihinsa ja linkkaa niiden tiedostot hakemistoon <code>/opt/homebrew</code>.

--- a/_data/locales/fr.yml
+++ b/_data/locales/fr.yml
@@ -3,6 +3,7 @@ fr:
   subtitle: Le gestionnaire de paquets pour macOS
   pagecontent:
     search: Search
+    language: Langue
     question: Que fait Homebrew ?
     what: Homebrew installe <a href="https://formulae.brew.sh/formula/" title="Liste des paquets de Homebrew">ce dont vous avez besoin</a> et qu’Apple n’a pas installé.
     how: Homebrew installe les paquets dans leurs propres répertoires et crée des liens symboliques de leurs fichiers vers <code>/opt/homebrew</code>.

--- a/_data/locales/gl.yml
+++ b/_data/locales/gl.yml
@@ -3,6 +3,7 @@ gl:
   subtitle: O xestor de paquetes de macOS que faltaba
   pagecontent:
     search: Search
+    language: Lingua
     question: Que fai Homebrew?
     what: Homebrew instala <a href="https://formulae.brew.sh/formula/" title="Listaxe de paquetes Homebrew">todo aquilo que precisas</a> e que Apple non instala.
     how: Homebrew instala paquetes nos seus propios directorios e creando ligazóns simbólicas aos seus ficheiros en <code>/opt/homebrew</code>.

--- a/_data/locales/he.yml
+++ b/_data/locales/he.yml
@@ -3,6 +3,7 @@ he:
   subtitle: מנהל החבילות החסרות עבור macOS
   pagecontent:
     search: חיפוש בתוך
+    language: שפה
     question: מה Homebrew עושה?
     what: Homebrew מתקין את <a href="https://formulae.brew.sh/formula/" title="List of Homebrew packages">מה שצריך</a>, שאפל לא התקינה.
     how: Homebrew מתקין חבילות לתיקיות משלהן ואז יוצר symlinks לקבצים שלהן לתוך <code>/opt/homebrew</code>.

--- a/_data/locales/hi.yml
+++ b/_data/locales/hi.yml
@@ -3,6 +3,7 @@ hi:
   subtitle: macOS (या Linux) के लिए गुम पैकेज प्रबंधक
   pagecontent:
     search: Search
+    language: भाषा
     question: Homebrew क्या करता है?
     what: Homebrew आपके लिए आवश्यक <a href="https://formulae.brew.sh/formula/" title="Homebrew पैकेज की सूची">सामान</a> को स्थापित करता है जो Apple (या आपके Linux सिस्टम) ने नहीं किया।
     how: Homebrew हर पैकेज को उनके ही डायरेक्टरी में स्थापित करता है और फिर <code>/opt/homebrew</code> में उनके फ़ाइलों को प्रतीकात्मक लिंक देता है।

--- a/_data/locales/hu.yml
+++ b/_data/locales/hu.yml
@@ -3,6 +3,7 @@ hu:
   subtitle: A Hiányzó Csomagkezelő macOS-re (és Linux-ra)
   pagecontent:
     search: Keresés
+    language: Nyelv
     question: Mit tud a Homebrew?
     what: A Homebrew telepíti azokat a dolgokat, <a href="https://formulae.brew.sh/formula/" title="List of Homebrew packages">amik kellenek neked</a>, de az Apple (vagy Linux rendszered) nem.
     how: A Homebrew a csomagokat a saját mappájukba telepíti, aztán a fájloknak egy szimbólikus linket hoz létre a <code>/opt/homebrew</code> mappába (az Apple Silicon-on).

--- a/_data/locales/id.yml
+++ b/_data/locales/id.yml
@@ -3,6 +3,7 @@ id:
   subtitle: Pengelola Paket yang Hilang untuk macOS (atau Linux)
   pagecontent:
     search: Cari
+    language: Bahasa
     question: Apa Yang Homebrew Bisa Lakukan?
     what: Homebrew dapat menginstal <a href="https://formulae.brew.sh/formula/" title="Daftar paket Homebrew">barang yang kamu butuhkan</a> yang Apple (atau sistem Linux Anda) tidak menyediakan.
     how: Homebrew menginstal paket ke direktori mereka sendiri dan kemudian menghubungkan file mereka ke <code>/opt/homebrew</code>.

--- a/_data/locales/it.yml
+++ b/_data/locales/it.yml
@@ -3,6 +3,7 @@ it:
   subtitle: Il gestore di pacchetti mancanti per macOS
   pagecontent:
     search: Search
+    language: Lingua
     question: Che fa Homebrew?
     what: Homebrew installa <a href="https://formulae.brew.sh/formula/" title="List of Homebrew packages">quello che ti serve</a> e che Apple non ha installato.
     how: Homebrew installa i pacchetti nelle loro directory e crea un collegamento simbolico in <code>/opt/homebrew</code>.

--- a/_data/locales/ja.yml
+++ b/_data/locales/ja.yml
@@ -3,6 +3,7 @@ ja:
   subtitle: macOS（またはLinux）用パッケージマネージャー
   pagecontent:
     search: 検索
+    language: 言語
     question: Homebrewはどんなことをする？
     what: Homebrewではアップル（またはあなたのLinuxシステム）が提供していない<a href="https://formulae.brew.sh/formula/" title="Homebrewパッケージのリスト">あなたの必要なもの</a>をインストールできます。
     how: Homebrewは自身のディレクトリーにパッケージをインストールし、それらへのシンボリックリンクを<code>/opt/homebrew</code>に作成します。

--- a/_data/locales/ko.yml
+++ b/_data/locales/ko.yml
@@ -3,6 +3,7 @@ ko:
   subtitle: macOS 용 패키지 관리자
   pagecontent:
     search: Search
+    language: 언어
     question: Homebrew로 무엇을 할 수 있나요?
     what: Homebrew는 Apple(또는 Linux 시스템)에서 제공하지 않는 <a href="https://formulae.brew.sh/formula/" title="List of Homebrew packages">유용한 패키지 관리자</a>를 설치합니다.
     how: Homebrew는 전용 디렉토리에 패키지를 설치하고 <code>/opt/homebrew</code> 위치로 심볼릭 링크를 연결합니다.

--- a/_data/locales/ku.yml
+++ b/_data/locales/ku.yml
@@ -3,6 +3,7 @@ ku:
   subtitle:  macOS (یان Linux) بەڕێوبەری پاکێجە
   pagecontent:
     search: گەڕان
+    language: زمان
     question: هۆمبریو دەتوانێت چیت بۆ بکات؟
     what: هۆمبریو دەست دەکات بە داگرتنی <a href="https://formulae.brew.sh/formula/" title="List of Homebrew packages">ئەو شتانەی تۆ پێووستە</a> کە ئەپڵ (یان سیستەمی لینوکسەکەت) نەیوست.
     how: هۆمبریو پاکێجەکان دادەگرێت و یارمەتیت دەدات لەگەڵ لینککردنیان لەگەڵ سیستەم لە <code>/opt/homebrew</code>.

--- a/_data/locales/lb.yml
+++ b/_data/locales/lb.yml
@@ -3,6 +3,7 @@ lb:
   subtitle: Den feelenden Packungsverwalter fir macOS (oder dengem Linux system)
   pagecontent:
     search: Sich
+    language: Sprooch
     question: Wat mécht Homebrew?
     what: Homebrew installéiert <a href="https://formulae.brew.sh/formula/" title="Lëscht vun Homebrew Packungen">wat’s du brauchs</a> an wat Apple (oder däi Linux System) net schon fir dech installéiert huet.
     how: Homebrew installéiert Packungen an hirem eegenen Directory an symlinked dann hir files an <code>/opt/homebrew</code> eran.

--- a/_data/locales/nb.yml
+++ b/_data/locales/nb.yml
@@ -3,6 +3,7 @@ nb:
   subtitle: macOS’ manglende pakkebehandler
   pagecontent:
     search: Search
+    language: Språk
     question: What Does Homebrew Do?
     what: Homebrew installerer <a href="https://formulae.brew.sh/formula/" title="Liste over Homebrew-pakker">alt du trenger</a> som Apple ikke har installert.
     how: Homebrew installerer pakker i egne mapper, og symlinker filene i <code>/opt/homebrew</code>.

--- a/_data/locales/nl.yml
+++ b/_data/locales/nl.yml
@@ -3,6 +3,7 @@ nl:
   subtitle: De ontbrekende pakketbeheerder voor macOS (of Linux)
   pagecontent:
     search: Zoeken in
+    language: Taal
     question: Wat doet Homebrew?
     what: Homebrew installeert <a href="https://formulae.brew.sh/formula/" title="Lijst van Homebrew-pakketten">dingen die je nodig hebt</a>, die Apple niet levert.
     how: Homebrew installeert pakketten in hun eigen map en plaatst symlinks naar hun bestanden in <code>/opt/homebrew</code>.

--- a/_data/locales/nn.yml
+++ b/_data/locales/nn.yml
@@ -3,6 +3,7 @@ nn:
   subtitle: MacOS sin manglande pakkehandsamar
   pagecontent:
     search: Search
+    language: Språk
     question: Kva gjer Homebrew?
     what: Homebrew installerer <a href="https://formulae.brew.sh/formula/" title="Liste over Homebrew-pakkar">alt du treng</a> som Apple ikkje installerte.
     how: Homebrew installerer pakkar i eigne mapper, og symlenker filene i <code>/opt/homebrew</code>.

--- a/_data/locales/pl.yml
+++ b/_data/locales/pl.yml
@@ -3,6 +3,7 @@ pl:
   subtitle: Brakujący menadżer pakietów dla macOS
   pagecontent:
     search: Szukaj
+    language: Język
     question: Jak działa Homebrew?
     what: Homebrew instaluje <a href="https://formulae.brew.sh/formula/" title="Lista pakietów Homebrew">programy</a>, o których zapomniało Apple.
     how: Homebrew instaluje pakiety do ich własnego katalogu, po czym symlinkuje ich pliki w <code>/opt/homebrew</code>.

--- a/_data/locales/pt-br.yml
+++ b/_data/locales/pt-br.yml
@@ -3,6 +3,7 @@ pt-br:
   subtitle: O gerenciador de pacotes que faltava para o macOS (ou Linux)
   pagecontent:
     search: Search
+    language: Língua
     question: O Que O Homebrew Faz?
     what: O Homebrew instala <a href="https://formulae.brew.sh/formula/" title="Lista de pacotes do Homebrew">as coisas que você precisa</a> que a Apple (ou o seu sistema Linux) não forneceram para você.
     how: O Homebrew instala os pacotes em seu próprio diretório e cria links simbólicos dos seus arquivos dentro de <code>/opt/homebrew</code>.

--- a/_data/locales/pt.yml
+++ b/_data/locales/pt.yml
@@ -3,6 +3,7 @@ pt:
   subtitle: O gestor de pacotes que faltava para o macOS (ou Linux)
   pagecontent:
     search: Search
+    language: Língua
     question: O que faz o Homebrew?
     what: O Homebrew instala <a href="https://formulae.brew.sh/formula/" title="Lista de pacotes do Homebrew">aquilo que precisas</a> e que a Apple (ou o seu sistema Linux) não disponibilizam.
     how: O Homebrew instala os pacotes no seu próprio diretório e cria ligações simbólicas dos seus ficheiros dentro de <code>/opt/homebrew</code>. (em Apple Silicon).

--- a/_data/locales/ro.yml
+++ b/_data/locales/ro.yml
@@ -3,6 +3,7 @@ ro:
   subtitle: Managerul de module care lipseste de pe macOS
   pagecontent:
     search: Caută
+    language: Limbă
     question: Ce face Homebrew?
     what: Homebrew instalează <a href="https://formulae.brew.sh/formula/" title="Lista cu modulele Homebrew">chestiile de care ai nevoie</a> și pe care Apple (sau sistemul tău Linux) nu o face.
     how: Homebrew instalează modulele în propriile lor directoare creând symlink-uri pentru fiecare în <code>/opt/homebrew</code>.

--- a/_data/locales/ru.yml
+++ b/_data/locales/ru.yml
@@ -3,6 +3,7 @@ ru:
   subtitle: Менеджер недостающих пакетов для macOS
   pagecontent:
     search: Search
+    language: Язык
     question: Что делает Homebrew?
     what: Homebrew устанавливает <a href="https://formulae.brew.sh/formula/" title="Список пакетов Homebrew">нужные вам пакеты</a>, не предоставляемые Apple.
     how: Homebrew устанавливает программы в их собственные директории и создает символьную ссылку на них в <code>/opt/homebrew</code>.

--- a/_data/locales/sr.yml
+++ b/_data/locales/sr.yml
@@ -3,6 +3,7 @@ sr:
   subtitle: Менаџер пакета који недостаје macOS-у
   pagecontent:
     search: Search
+    language: Језик
     question: Шта ради Homebrew?
     what: Homebrew инсталира <a href="https://formulae.brew.sh/formula/" title="List of Homebrew packages">ствари које вама требају</a>, а које Apple није.
     how: Homebrew инсталира пакете у њихову засебну директорију и симлинкује их у <code>/opt/homebrew</code>.

--- a/_data/locales/sv.yml
+++ b/_data/locales/sv.yml
@@ -3,6 +3,7 @@ sv:
   subtitle: Den efterlängtade pakethanteraren för macOS (eller Linux)
   pagecontent:
     search: Sök
+    language: Språk
     question: Vad gör Homebrew?
     what: Homebrew installerar <a href="https://formulae.brew.sh/formula/" title="Lista av Homebrew-paket">allt du behöver</a> som Apple inte redan har gjort.
     how: Homebrew installerar paket i egna mappar och symlänkar sedan dessa filer till <code>/opt/homebrew</code>.

--- a/_data/locales/ta.yml
+++ b/_data/locales/ta.yml
@@ -3,6 +3,7 @@ ta:
   subtitle: MacOS (அல்லது Linux)க்கான காணாமல் போன தொகுப்பு மேலாளர்
   pagecontent:
     search: தேடு
+    language: மொழி
     question: Homebrew என்ன செய்கிறது?
     what: Homebrew நிறுவுகிறது <a href="https://formulae.brew.sh/formula/" title="Homebrew தொகுப்புகளின் பட்டியல்">உங்களுக்கு தேவையான பொருட்கள்</a> Apple (அல்லது உங்கள் Linux அமைப்பு) செய்யாதது.
     how: Homebrew அவர்களின் சொந்த கோப்பகத்தில் தொகுப்புகளை நிறுவி, அதன் கோப்புகளை <code>/opt/homebrew</code> க்கு குறியீட்டு இணைக்கிறது (Apple Silicon இல்).

--- a/_data/locales/th.yml
+++ b/_data/locales/th.yml
@@ -3,6 +3,7 @@ th:
   subtitle: แพคเกจเมเนเจอร์ที่ขาดหายไปของ macOS
   pagecontent:
     search: ค้นหา
+    language: ภาษา
     question: Homebrew ทำอะไรได้บ้าง?
     what: Homebrew ติดตั้ง<a href="https://formulae.brew.sh/formula/" title="List of Homebrew packages">สิ่งที่คุณต้องการ</a>ที่ Apple ไม่ได้ให้มา
     how: Homebrew ติดตั้งแพคเกจต่าง ๆ ไปที่ไดเรคทอรี่ที่แยกไว้ต่างหาก จากนั้นทำการ symlinks ไฟล์เหล่านั้นไปที่ <code>/opt/homebrew</code>

--- a/_data/locales/tr.yml
+++ b/_data/locales/tr.yml
@@ -3,6 +3,7 @@ tr:
   subtitle: macOS (veya Linux) için eksik paket yöneticisi
   pagecontent:
     search: Ara
+    language: Dil
     question: Homebrew ne yapar?
     what: Homebrew Apple’ın (ya da Linux sisteminizin) ihtiyaç duymadığı ama <a href="https://formulae.brew.sh/formula/" title="Homebrew paketlerinin bir listesi">size lazım olabilecek paketleri</a> kurmanızı sağlar.
     how: Homebrew paketleri kendi dizinlerinin altından <code>/opt/homebrew</code>’a kısayollar ile bağlar.

--- a/_data/locales/uk.yml
+++ b/_data/locales/uk.yml
@@ -3,6 +3,7 @@ uk:
   subtitle: Відсутній менеджер пакетів для macOS (чи Linux)
   pagecontent:
     search: Пошук
+    language: Мова
     question: Для чого потрібен Homebrew?
     what: Homebrew встановлює <a href="https://formulae.brew.sh/formula/" title="Список Homebrew-програм">необхідні Вам програми</a>, яких немає в Apple (чи Linux).
     how: Homebrew встановлює пакети у власний каталог, а потім додає символьне посилання (префікс) для їх файлів <code>/opt/homebrew</code> (on Apple Silicon).

--- a/_data/locales/vi.yml
+++ b/_data/locales/vi.yml
@@ -3,6 +3,7 @@ vi:
   subtitle: Trình quản lý gói mà macOS thiếu
   pagecontent:
     search: Search
+    language: Ngôn ngữ
     question: What Does Homebrew Do?
     what: Homebrew cài <a href="https://formulae.brew.sh/formula/" title="List of Homebrew packages">thứ bạn cần</a> mà Apple không cung cấp.
     how: Homebrew cài các gói vào thư mục riêng và kết nối mềm các tập tin vào <code>/opt/homebrew</code>.

--- a/_data/locales/zh-cn.yml
+++ b/_data/locales/zh-cn.yml
@@ -3,6 +3,7 @@ zh-cn:
   subtitle: macOS（或 Linux）缺失的软件包的管理器
   pagecontent:
     search: Search
+    language: 语言
     question: Homebrew 能干什么?
     what: 使用 Homebrew 安装 Apple（或您的 Linux 系统）没有预装但 <a href="https://formulae.brew.sh/formula/" title="Homebrew 软件包列表">你需要的东西</a>。
     how: Homebrew 会将软件包安装到独立目录，并将其文件软链接至 <code>/opt/homebrew</code> 。

--- a/_data/locales/zh-tw.yml
+++ b/_data/locales/zh-tw.yml
@@ -3,6 +3,7 @@ zh-tw:
   subtitle: 為 macOS（或 Linux）添上套件管理工具
   pagecontent:
     search: 搜尋
+    language: 語言
     question: Homebrew 能做什麼？
     what: 使用 Homebrew 安裝 Apple（或您的 Linux 系統）沒有預裝，但是<a href="https://formulae.brew.sh/formula/" title="Homebrew 套件一覽">你需要的東西</a>。
     how: Homebrew 會將套件安裝在它們自己的目錄，然後把檔案 symlink 到 (Apple Silicon) <code>/opt/homebrew</code> 下。

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -87,7 +87,13 @@ algolia:
         <div id="search-container"></div>
 
         {% if page.lang -%}
-          <select id="language" onchange="loadLanguage(this.options[this.selectedIndex].value)">
+          {% if t.pagecontent.language -%}
+            {% assign language_text = t.pagecontent.language -%}
+          {% else -%}
+            {% assign language_text = site.data.locales.en.en.pagecontent.language -%}
+          {% endif -%}
+          <label class="hidden" for="language">{{ language_text }}</label>
+          <select id="language" name="language" title="{{ language_text }}" aria-label="{{ language_text }}" onchange="loadLanguage(this.options[this.selectedIndex].value)">
             {% for locale in locales -%}
               {% assign lang = locale[0] -%}
               {% assign locale_name = locale[1][lang].locale_name -%}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -45,6 +45,10 @@ $grey_90: rgba(127, 127, 127, 0.9);
   -webkit-margin-end: $margin;
 }
 
+.hidden {
+  display: none;
+}
+
 h1, h2, h3 {
   font-size: 420%;
   color: $color_peach_orange_approx;


### PR DESCRIPTION
As @colindean mentioned in #977, the language `select` element could benefit from having a label. This PR adds an `aria-label` attribute (for screen readers) as well as a hidden `label` element (for text browsers). The latter is hidden (using CSS) to maintain the current look of the website (assuming we don't want to see a "Language" label next to the `select` box on the page).

This adds a `pagecontent.language` value to the translation files and sets the text to fall back to the English value when it's not present for a given language. I've added translations for all the existing languages, using a combination of Google Translate, [Wiktionary](https://en.wiktionary.org/wiki/language/translations), language-specific dictionaries, websites in the native language (e.g., Wikipedia), etc. Outside of the handful of languages that I have experience with, I can't guarantee that the translations are 100% perfect but I've used everything at my disposal to get as close as possible, at least.

Fixes #977.