### PR TITLE
Replace self-closing tags in plugin output

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -39,10 +39,21 @@ algolia:
     {% else -%}
       <title>{{ site.title }}</title>
     {% endif -%}
-    {% seo title=false -%}
-    {% if site.feed -%}
-      {% include feed.html -%}
-    {% endif %}
+    {% comment -%}
+      The `jekyll-feed` and `jekyll-seo-tag` plugins use self-closing tags (for
+      XHTML compatibility) and, while it's still valid for an HTML5 DOCTYPE,
+      this leads to many `info` notices when running the HTML through a
+      validator. There's no way for us to control this behavior in the plugins,
+      so our only option is to capture the plugin output and naively remove the
+      trailing slash at the end of self-closing tags.
+    {% endcomment -%}
+    {% capture plugin_output -%}
+      {% seo title=false -%}
+      {% if site.feed -%}
+        {% include feed.html -%}
+      {% endif -%}
+    {% endcapture -%}
+    {{ plugin_output | replace: " />", ">" | replace: "/>", ">" -}}
     <meta name="viewport" content="width=device-width">
     <link rel="icon" type="image/x-icon" href="{{ "/assets/img/favicon.ico" | relative_url }}">
     <link rel="apple-touch-icon" href="{{ "/assets/img/apple-touch-icon.png" | relative_url }}">

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -112,7 +112,14 @@ algolia:
         {% endif -%}
       </div>
 
-      {{ content }}
+      {% comment -%}
+        This is primarily intended to remove the trailing slash from the
+        self-closing `img` tags that result from rendered Markdown text.
+      {% endcomment -%}
+      {% capture rendered_content -%}
+        {{ content }}
+      {% endcapture -%}
+      {{ rendered_content | replace: " />", ">" | replace: "/>", ">" -}}
     </div>
 
     {% if site.forkme_nwo -%}


### PR DESCRIPTION
The `jekyll-seo-tag` and `jekyll-feed` plugins use self-closing tags (e.g., `<... />`) since they support XHTML but there's no way to override this within the plugins. Self-closing void tags in HTML5 is optional behavior but it creates a bunch of noise in HTML validators unless we restrict the output to errors. Resolving this issue allows us to optionally run an HTML validator in the default mode (which also surfaces warning- and info-level issues) without having to sift through hundreds of lines of output about self-closing tags.

This commit introduces some logic into the `base.html` layout that removes trailing slashes in the plugin output, as this is the only area where we have self-closing tags at this point.

[We will probably want to only check for errors on CI if/when we add it in the future but being able to check for warnings when doing local development is helpful. For what it's worth, I'm running the [W3C validator](https://validator.w3.org) locally using `vnu` (e.g., `vnu --skip-non-html  _site/**/*.html` from within the `brew.sh` directory).]