### PR TITLE
Remove extra closing anchor tag

### DIFF
--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -27,7 +27,7 @@ layout: base
           <p>{{ t.pagecontent.install.pkginstaller }}</p>
         </div>
         <div class="col-2">
-          <p>{{ t.pagecontent.install.githubrelease }}</a></p>
+          <p>{{ t.pagecontent.install.githubrelease }}</p>
         </div>
       </div>
     </li>


### PR DESCRIPTION
The `pagecontent.install.githubrelease` text already contains a closing anchor tag, so the closing `a` tag in the `index.html` template doesn't have a corresponding opening `a` tag. This currently produces an HTML validation error: `error: Stray end tag “a”`.

This commit resolves the issue by removing the extra anchor tag in the `index.html` template.