### PR TITLE
Update missing URL

### DIFF
--- a/_data/locales/tr.yml
+++ b/_data/locales/tr.yml
@@ -31,4 +31,4 @@ tr:
     foot:
       code: Özgün kodu yazan <a href="https://mxcl.github.io/">Max Howell</a>.
       page: Siteyi hazırlayanlar <a href="https://exomel.com/">Rémi Prévost</a>, <a href="https://mikemcquaid.com">Mike McQuaid</a>, <a href="https://cargocollective.com/danilalo">Danielle Lalonde</a>.
-      translation: Tercüme edenler <a href="https://github.com/hemlockII">hemlockII</a>, <a href="https://ziyaddin.github.io">Ziyaddin Sadigov</a>, <a href="https://github.com/quaertym">Emre Ünal</a>, <a href="https://github.com/serkanyersen">Serkan Yerşen</a>, <a href="https://github.com/okan">Okan</a>, <a href="https://enderahmetyurt.com">Ender Ahmet Yurt</a>, <a href="https://sadikkuzu.com">Sadık Kuzu</a>.
+      translation: Tercüme edenler <a href="https://github.com/hemlockII">hemlockII</a>, <a href="https://github.com/ziyaddin">Ziyaddin Sadigov</a>, <a href="https://github.com/quaertym">Emre Ünal</a>, <a href="https://github.com/serkanyersen">Serkan Yerşen</a>, <a href="https://github.com/okan">Okan</a>, <a href="https://enderahmetyurt.com">Ender Ahmet Yurt</a>, <a href="https://sadikkuzu.com">Sadık Kuzu</a>.


### PR DESCRIPTION
The HTML-Proofer test on CI is failing because
https://ziyaddin.github.io now returns a 404 (Not Found) response. This updates the URL to point to the user's GitHub page instead.

I originally included this fix in #983 but I've split it out into a separate PR, so we can get it merged quicker and rebase the open PRs.