### PR TITLE
Handle missing site.url for local development

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -67,8 +67,8 @@ algolia:
       {% for locale in locales -%}
         {% assign lang = locale[0] -%}
         {% if lang == "en" -%}
-          <link rel="alternate" hreflang="en" href="{{ site.url }}">
-          <link rel="alternate" hreflang="x-default" href="{{ site.url }}">
+          <link rel="alternate" hreflang="en" href="{% if site.url %}{{ site.url }}{% else %}/{% endif %}">
+          <link rel="alternate" hreflang="x-default" href="{% if site.url %}{{ site.url }}{% else %}/{% endif %}">
         {% else -%}
           <link rel="alternate" hreflang="{{ lang }}" href="{{ lang | prepend: '/index_' | prepend: site.url }}">
         {% endif -%}


### PR DESCRIPTION
We don't set `site.url` in our config and instead rely on it being set when the site is generated on GitHub Pages. Since `site.url` isn't set when doing local development, the `en` and `x-default` alternative language `link` elements end up with an empty `href` attribute. This leads to many `Bad value "" for attribute "href" on element "link": Must be non-empty` errors, which makes it harder to identify meaningful errors when working locally.

This resolves the issue for local development by using a fallback `/` value when `site.url` isn't set. [In this scenario, the other `href` values end up being relative (because prepending a non-existent `site.url` doesn't do anything), so using `/` as the fallback value aligns with the others.]

All of our generated HTML pages on the production site validate without errors or warnings now but this PR accomplishes the same for local development.