### PR TITLE
Add pretty permalink to alt lang index files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ the index is at `_layouts/index.html`.
 
 If you want to add a new translation, follow these steps:
 
-1. Copy `index.html` to `index_{langcode}.html` and update its `lang` value.
+1. Copy `index_fr.html` to `index_{langcode}.html` and update its `lang` and `permalink` values.
 2. Copy `_data/locales/en.yml` to `_data/locales/{langcode}.yml` and update its initial language code.
 3. Change the values of the English strings to the new, translated language strings.
 

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -70,7 +70,7 @@ algolia:
           <link rel="alternate" hreflang="en" href="{{ site.url }}">
           <link rel="alternate" hreflang="x-default" href="{{ site.url }}">
         {% else -%}
-          <link rel="alternate" hreflang="{{ lang }}" href="{{ lang | prepend: '/index_' | prepend: site.url }}">
+          <link rel="alternate" hreflang="{{ lang }}" href="{{ lang | prepend: '/' | prepend: site.url }}">
         {% endif -%}
       {% endfor -%}
     {% endif -%}
@@ -151,7 +151,7 @@ algolia:
         } else if (lang === 'en') {
           window.location.assign('/');
         } else {
-          window.location.assign('/index_' + lang);
+          window.location.assign('/' + lang);
         }
       }
 

--- a/index_ar.html
+++ b/index_ar.html
@@ -2,4 +2,5 @@
 layout: index
 lang: ar
 direction: rtl
+permalink: /ar/
 ---

--- a/index_az.html
+++ b/index_az.html
@@ -1,4 +1,5 @@
 ---
 layout: index
 lang: az
+permalink: /az/
 ---

--- a/index_be.html
+++ b/index_be.html
@@ -1,4 +1,5 @@
 ---
 layout: index
 lang: be
+permalink: /be/
 ---

--- a/index_bg.html
+++ b/index_bg.html
@@ -1,4 +1,5 @@
 ---
 layout: index
 lang: bg
+permalink: /bg/
 ---

--- a/index_ca.html
+++ b/index_ca.html
@@ -1,4 +1,5 @@
 ---
 layout: index
 lang: ca
+permalink: /ca/
 ---

--- a/index_cs.html
+++ b/index_cs.html
@@ -1,4 +1,5 @@
 ---
 layout: index
 lang: cs
+permalink: /cs/
 ---

--- a/index_da.html
+++ b/index_da.html
@@ -1,4 +1,5 @@
 ---
 layout: index
 lang: da
+permalink: /da/
 ---

--- a/index_de.html
+++ b/index_de.html
@@ -1,4 +1,5 @@
 ---
 layout: index
 lang: de
+permalink: /de/
 ---

--- a/index_el.html
+++ b/index_el.html
@@ -1,4 +1,5 @@
 ---
 layout: index
 lang: el
+permalink: /el/
 ---

--- a/index_es.html
+++ b/index_es.html
@@ -1,4 +1,5 @@
 ---
 layout: index
 lang: es
+permalink: /es/
 ---

--- a/index_fa.html
+++ b/index_fa.html
@@ -2,4 +2,5 @@
 layout: index
 lang: fa
 direction: rtl
+permalink: /fa/
 ---

--- a/index_fi.html
+++ b/index_fi.html
@@ -1,4 +1,5 @@
 ---
 layout: index
 lang: fi
+permalink: /fi/
 ---

--- a/index_fr.html
+++ b/index_fr.html
@@ -1,4 +1,5 @@
 ---
 layout: index
 lang: fr
+permalink: /fr/
 ---

--- a/index_gl.html
+++ b/index_gl.html
@@ -1,4 +1,5 @@
 ---
 layout: index
 lang: gl
+permalink: /gl/
 ---

--- a/index_he.html
+++ b/index_he.html
@@ -2,4 +2,5 @@
 layout: index
 lang: he
 direction: rtl
+permalink: /he/
 ---

--- a/index_hi.html
+++ b/index_hi.html
@@ -1,4 +1,5 @@
 ---
 layout: index
 lang: hi
+permalink: /hi/
 ---

--- a/index_hu.html
+++ b/index_hu.html
@@ -1,4 +1,5 @@
 ---
 layout: index
 lang: hu
+permalink: /hu/
 ---

--- a/index_id.html
+++ b/index_id.html
@@ -1,4 +1,5 @@
 ---
 layout: index
 lang: id
+permalink: /id/
 ---

--- a/index_it.html
+++ b/index_it.html
@@ -1,4 +1,5 @@
 ---
 layout: index
 lang: it
+permalink: /it/
 ---

--- a/index_ja.html
+++ b/index_ja.html
@@ -1,4 +1,5 @@
 ---
 layout: index
 lang: ja
+permalink: /ja/
 ---

--- a/index_ko.html
+++ b/index_ko.html
@@ -1,4 +1,5 @@
 ---
 layout: index
 lang: ko
+permalink: /ko/
 ---

--- a/index_ku.html
+++ b/index_ku.html
@@ -1,4 +1,5 @@
 ---
 layout: index
 lang: ku
+permalink: /ku/
 ---

--- a/index_lb.html
+++ b/index_lb.html
@@ -1,4 +1,5 @@
 ---
 layout: index
 lang: lb
+permalink: /lb/
 ---

--- a/index_nb.html
+++ b/index_nb.html
@@ -1,4 +1,5 @@
 ---
 layout: index
 lang: nb
+permalink: /nb/
 ---

--- a/index_nl.html
+++ b/index_nl.html
@@ -1,4 +1,5 @@
 ---
 layout: index
 lang: nl
+permalink: /nl/
 ---

--- a/index_nn.html
+++ b/index_nn.html
@@ -1,4 +1,5 @@
 ---
 layout: index
 lang: nn
+permalink: /nn/
 ---

--- a/index_pl.html
+++ b/index_pl.html
@@ -1,4 +1,5 @@
 ---
 layout: index
 lang: pl
+permalink: /pl/
 ---

--- a/index_pt-br.html
+++ b/index_pt-br.html
@@ -1,4 +1,5 @@
 ---
 layout: index
 lang: pt-br
+permalink: /pt-br/
 ---

--- a/index_pt.html
+++ b/index_pt.html
@@ -1,4 +1,5 @@
 ---
 layout: index
 lang: pt
+permalink: /pt/
 ---

--- a/index_ro.html
+++ b/index_ro.html
@@ -1,4 +1,5 @@
 ---
 layout: index
 lang: ro
+permalink: /ro/
 ---

--- a/index_ru.html
+++ b/index_ru.html
@@ -1,4 +1,5 @@
 ---
 layout: index
 lang: ru
+permalink: /ru/
 ---

--- a/index_sr.html
+++ b/index_sr.html
@@ -1,4 +1,5 @@
 ---
 layout: index
 lang: sr
+permalink: /sr/
 ---

--- a/index_sv.html
+++ b/index_sv.html
@@ -1,4 +1,5 @@
 ---
 layout: index
 lang: sv
+permalink: /sv/
 ---

--- a/index_ta.html
+++ b/index_ta.html
@@ -1,4 +1,5 @@
 ---
 layout: index
 lang: ta
+permalink: /ta/
 ---

--- a/index_th.html
+++ b/index_th.html
@@ -1,4 +1,5 @@
 ---
 layout: index
 lang: th
+permalink: /th/
 ---

--- a/index_tr.html
+++ b/index_tr.html
@@ -1,4 +1,5 @@
 ---
 layout: index
 lang: tr
+permalink: /tr/
 ---

--- a/index_uk.html
+++ b/index_uk.html
@@ -1,4 +1,5 @@
 ---
 layout: index
 lang: uk
+permalink: /uk/
 ---

--- a/index_vi.html
+++ b/index_vi.html
@@ -1,4 +1,5 @@
 ---
 layout: index
 lang: vi
+permalink: /vi/
 ---

--- a/index_zh-cn.html
+++ b/index_zh-cn.html
@@ -1,4 +1,5 @@
 ---
 layout: index
 lang: zh-cn
+permalink: /zh-cn/
 ---

--- a/index_zh-tw.html
+++ b/index_zh-tw.html
@@ -1,4 +1,5 @@
 ---
 layout: index
 lang: zh-tw
+permalink: /zh-tw/
 ---


### PR DESCRIPTION
The existing alternative language files currently use an `/index_{langcode}.html` path. While this is perfectly functional, it's not as pretty as it could be. It's not uncommon for websites to use a language path for alternative languages (e.g., `/fr/`) when they use one domain for all languages.

This commit adds a `permalink` value to the front matter of all the alternative language index files, so they will use cleaner URLs. This also updates the URLs used in the `link` tags and the JavaScript for the language `select` element accordingly.