### PR TITLE
Avoid render-blocking with Algolia CSS

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -74,7 +74,7 @@ algolia:
         {% endif -%}
       {% endfor -%}
     {% endif -%}
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3/dist/style.min.css">
+    <link rel="preload" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3/dist/style.min.css" as="style" media="screen" onload="this.onload=null;this.rel='stylesheet'">
     {% if page.url == "/" -%}
       {% for rel_me_url in site.link_rel_me_urls -%}
         <link href="{{rel_me_url}}" rel="me">


### PR DESCRIPTION
The Algolia CSS only applies to the search box (which renders dynamically), so we can safely defer it. This resolves the "Eliminate render-blocking resources" item in PageSpeed Insights and Lighthouse.