### PR TITLE
Use minimum font-size of 12px

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -282,7 +282,7 @@ pre {
 
   code {
     font-family: "Monaco", "Menlo", monospace;
-    font-size: 11px;
+    font-size: 80%;
     line-height: 1.6;
   }
 }
@@ -497,7 +497,7 @@ button::-moz-focus-inner {
 
   .credits {
     border-bottom: none;
-    font-size: 70%;
+    font-size: 80%;
     text-align: center;
     padding-top: 1.8em;
 
@@ -528,7 +528,7 @@ button::-moz-focus-inner {
 
 #border-no-bottom {
   border-bottom: none;
-  font-size: 70%;
+  font-size: 80%;
   text-align: center;
   padding-top: 1.8em;
   opacity: 0.5;


### PR DESCRIPTION
PageSpeed Insights and Lighthouse complain about text that's smaller than 12px (for mobile). Our styling for `pre code` and `#information .credits` both use a `font-size` that's smaller than 12px (11px and ~11.5281px respectively).

This increases the smallest `font-size` values in `style.scss` to 12px (80% in this case).