### PR TITLE
Homebrew 4.2.0

### DIFF
--- a/_posts/2023-12-18-homebrew-4.2.0.md
+++ b/_posts/2023-12-18-homebrew-4.2.0.md
@@ -1,0 +1,68 @@
+---
+title: 4.2.0
+author: MikeMcQuaid
+redirect_from: /blog/4.2.0/
+---
+
+Today, I'd like to announce Homebrew 4.2.0.
+The most significant changes since 4.1.0 are some major performance upgrades (e.g. using Ruby 3.1, upgrading fewer dependencies), `.env` file configuration and macOS Sonoma support.
+
+Major changes and deprecations since 4.1.0:
+
+- Homebrew now uses and [requires Ruby 3.1](https://github.com/Homebrew/brew/pull/16294).
+  If you do not already have a version provided by your system: we provide
+  [Portable Ruby 3.1.4](https://github.com/Homebrew/brew/pull/16145) that will be installed whenever needed on
+  Linux x86_64 and macOS Apple Silicon and Intel.
+  This marks the end of Homebrew using the macOS system Ruby.
+  Pour one out for our old friend `/usr/bin/ruby` on macOS 🍻.
+- [Formula installation and upgrades are less likely to require dependencies to be upgraded.](https://github.com/Homebrew/brew/pull/15927)
+  This should reduce "`brew upgrade foo` upgraded everything on my system" problems.
+- Homebrew/homebrew-core and Homebrew/homebrew-cask now store formulae/casks in "sharded" subdirectories for improved `git` and GitHub performance.
+- [Homebrew can be configured with `.env` files.](https://github.com/Homebrew/brew/pull/15787)
+- [Homebrew supports macOS Sonoma.](https://github.com/Homebrew/brew/pull/16019)
+- [`OS::Mac` and `MacOS` usage in formulae on Linux is deprecated.](https://github.com/Homebrew/brew/pull/16224)
+  Please guard all uses in formulae with `if OS.mac?` or `if OS.linux?` as appropriate.
+- [`brew audit --new-formula` and `--new-cask` options are deprecated.](https://github.com/Homebrew/brew/pull/16297)
+  Please use `brew audit --new` instead.
+- [`brew postgresql-upgrade-database` is deprecated.](https://github.com/Homebrew/brew/pull/15799)
+  It is not longer needed now that we use versioned `postgresql` formulae.
+  Please use `pg_upgrade` directly instead.
+- [Casks can be, like formulae, deprecated and disabled.](https://github.com/Homebrew/brew/pull/16292)
+  [Relatedly, the use of `discontinued?` in casks is deprecated.](https://github.com/Homebrew/brew/pull/16352)
+- [Various other deprecations.](https://github.com/Homebrew/brew/pull/15632)
+
+
+Other changes since 4.1.0 I'd like to highlight are the following:
+
+- [Homebrew detects Apple Silicon M3 processors.](https://github.com/Homebrew/brew/pull/16278)
+- [The macOS `.pkg` installer is signed (by me!).](https://github.com/Homebrew/brew/pull/15743)
+- [Casks support setting multiple download headers](https://github.com/Homebrew/brew/pull/15602)
+- [`brew list --full-names` properly output Homebrew organisation names for casks.](https://github.com/Homebrew/brew/pull/16328)
+- [Homebrew uses Sorbet for runtime error checking.](https://github.com/Homebrew/brew/pull/15705)
+- [Homebrew is importing parts of ActiveSupport](https://github.com/Homebrew/brew/pull/16184)
+  [to speed up](https://github.com/Homebrew/brew/pull/16259)
+  [command execution time.](https://github.com/Homebrew/brew/pull/16320)
+- [Homebrew supports the `rc` shell.](https://github.com/Homebrew/brew/pull/16265)
+- [Various sharding fixes](https://github.com/Homebrew/brew/pull/15811)
+- [Downloads from the Homebrew API better support](https://github.com/Homebrew/brew/pull/16078)
+  [if `curl` or system certificates are too old.](https://github.com/Homebrew/brew/pull/15895)
+- [`brew deps` no longer passes options to formulae.](https://github.com/Homebrew/brew/pull/15922)
+- [`brew desc` has improved handling of`--eval-all` with formulae.](https://github.com/Homebrew/brew/pull/16195)
+- [`brew install` will upgrade already installed casks (to be consistent with formulae.)](https://github.com/Homebrew/brew/pull/15746)
+- [`brew pin`'d formulae don't cause as many warnings or errors.](https://github.com/Homebrew/brew/pull/16301)
+- [`brew setup-ruby` is a new command to just install Homebrew's Ruby, if needed.](https://github.com/Homebrew/brew/pull/16147)
+- [`brew edit` will suggest tapping core repositories if untapped.](https://github.com/Homebrew/brew/pull/15740)
+- [The macOS `.pkg` installer is a documented installation method.](https://github.com/Homebrew/brew/pull/15755)
+- [Formula support `ENV.O3` again to allow passing `-O3` compiler optimisations.](https://github.com/Homebrew/brew/pull/15680)
+- [`brew install` sets `PIP_CACHE_DIR` to cache more Python files when building bottles or from source.](https://github.com/Homebrew/brew/pull/16250)
+- [`brew audit` checks all relicensed HashiCorp formulae.](https://github.com/Homebrew/brew/pull/15982)
+- [`sshpass` has (finally?) been removed from the new formula deny list.](https://github.com/Homebrew/brew/pull/15979)
+- [Formula's `service` blocks now support multiple sockets.](https://github.com/Homebrew/brew/pull/16026)
+- [`bootsnap` is used more often, speeding up repeated `brew` invocations.](https://github.com/Homebrew/brew/pull/16062)
+- [`XDG_CACHE_HOME` is used correctly again for logs and Homebrew's cache on Linux.](https://github.com/Homebrew/brew/pull/16161)
+
+Finally:
+
+- [Homebrew accepts donations through GitHub Sponsors](https://github.com/sponsors/Homebrew) and [still accepts donations through Patreon](https://www.patreon.com/homebrew). If you can afford it, please consider donating. If you'd rather not use GitHub Sponsors or Patreon (our preferred donation methods), [check out the other ways to donate in our README](https://github.com/homebrew/brew/#donations).
+
+Thanks to all our hard-working maintainers, contributors, sponsors and supporters for getting us this far.


### PR DESCRIPTION
Release notes blog post for Homebrew 4.2.0.

Note: make sure the mailing list is fixed before this gets sent out.