### PR TITLE
favicon: use `svg` logo for favicon when supported

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -55,7 +55,8 @@ algolia:
     {% endcapture -%}
     {{ plugin_output | replace: " />", ">" | replace: "/>", ">" -}}
     <meta name="viewport" content="width=device-width">
-    <link rel="icon" type="image/x-icon" href="{{ "/assets/img/favicon.ico" | relative_url }}">
+    <link rel="alternate icon" type="image/x-icon" sizes="any" href="{{ "/assets/img/favicon.ico" | relative_url }}">
+    <link rel="icon" type="image/svg+xml" href="{{ "/assets/img/homebrew.svg" | relative_url }}">
     <link rel="apple-touch-icon" href="{{ "/assets/img/apple-touch-icon.png" | relative_url }}">
     <link rel="stylesheet" href="{{ "/assets/css/style.css" | relative_url }}" type="text/css" media="screen">
     <link rel="preconnect" href="https://{{ layout.algolia.appId }}-dsn.algolia.net" crossorigin>


### PR DESCRIPTION
Modern browsers allow the use of an `svg` for the site favicon (this is not supported in Safari, so the `ico` will continue to be used).

Before:
<img width="139" alt="Screenshot 2024-01-21 at 9 47 50 pm" src="https://github.com/Homebrew/brew.sh/assets/40621599/45e4028f-651e-4f13-947d-0ead92694621">

After:
<img width="108" alt="Screenshot 2024-01-21 at 9 35 04 pm" src="https://github.com/Homebrew/brew.sh/assets/40621599/4c724dfa-07b3-48e2-849c-21e022306d14">
