### PR TITLE
Tweak formula display

### DIFF
--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -110,9 +110,11 @@ $ brew edit wget # {{ t.pagecontent.editor }}
         <div class="col-2">
 {% highlight ruby -%}
 class Wget < Formula
+  desc "Internet file retriever"
   homepage "https://www.gnu.org/software/wget/"
-  url "https://ftp.gnu.org/gnu/wget/wget-1.15.tar.gz"
-  sha256 "52126be8cf1bddd7536886e74c053ad7d0ed2aa89b4b630f76785bac21695fcd"
+  url "https://ftp.gnu.org/gnu/wget/wget-1.24.5.tar.gz"
+  sha256 "fa2dc35bab5184ecbc46a9ef83def2aaaa3f4c9f3c97d4bd19dcb07d4da637de"
+  license "GPL-3.0-or-later"
 
   def install
     system "./configure", "--prefix=#{prefix}"

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -154,7 +154,7 @@ html {
   margin: 0;
   padding: 0;
   font-size: 62.5%;
-  font-family: "-apple-system", "BlinkMacSystemFont", "Helvetica Neue", "Roboto", sans-serif;
+  font-family: "ui-sans-serif", "-apple-system", "BlinkMacSystemFont", "Helvetica Neue", "Roboto", sans-serif;
   height: 100%;
 }
 
@@ -281,7 +281,7 @@ pre {
   overflow-x: auto;
 
   code {
-    font-family: "Monaco", "Menlo", monospace;
+    font-family: "ui-monospace", "SF Mono", "Monaco", "Menlo", "Consolas", monospace;
     font-size: 11px;
     line-height: 1.6;
   }


### PR DESCRIPTION
- Add `desc` and `license` fields because they are required and look nice without adding too much more space.
- Improve the monospace font display to be the macOS native and use the new Safari `font-family` for the sans-serif too.