### PR TITLE
homebrew-4.3.0: clarify new portable Ruby.

### DIFF
--- a/_posts/2024-05-14-homebrew-4.3.0.md
+++ b/_posts/2024-05-14-homebrew-4.3.0.md
@@ -38,6 +38,8 @@ Major changes and deprecations since 4.2.0:
 
 - [`brew info --json=v2` output no longer includes the deprecated `oldname` key for formulae. Use the `oldnames` array instead.](https://github.com/Homebrew/brew/pull/17285)
 
+- [As-of Homebrew 4.3.1: Homebrew now provides Portable Ruby 3.3.1 and requires Ruby >=3.3.0.](https://github.com/Homebrew/brew/pull/17312)
+
 - [Miscellaneous additional code deprecation/disable/removals.](https://github.com/Homebrew/brew/pull/17233)
 
 Other changes since 4.2.0 I'd like to highlight are the following:


### PR DESCRIPTION
This didn't make 4.3.0 but in near enough after to justify inclusion.