### PR TITLE
misc: remove broken link

### DIFF
--- a/_posts/2019-01-09-homebrew-1.9.0.md
+++ b/_posts/2019-01-09-homebrew-1.9.0.md
@@ -40,7 +40,7 @@ Other changes since 1.8.0 I'd like to highlight are the following:
 - [`brew doctor` now outputs the non-default Xcode prefix to ease debugging when Homebrew is using one in a strange location](https://github.com/Homebrew/brew/pull/5358).
 - [`brew upgrade` will not upgrade formulae installed from one tap to formulae installed in another](https://github.com/Homebrew/brew/pull/5291).
 - [Homebrew now has a mission statement](https://github.com/Homebrew/brew/pull/5223).
-- [`Homebrew/brew` contains a `Dockerfile` for building Linuxbrew](https://github.com/Homebrew/brew/pull/5169). This is built automatically on [Linuxbrew's Docker Hub page](https://hub.docker.com/r/linuxbrew/linuxbrew/).
+- [`Homebrew/brew` contains a `Dockerfile` for building Linuxbrew](https://github.com/Homebrew/brew/pull/5169). This is built automatically on [Homebrew's Docker Hub page](https://hub.docker.com/r/homebrew/brew/).
 
 Finally:
 


### PR DESCRIPTION
This no longer exists, so let's update it to point to our Docker Hub.