### PR TITLE
set max-width of post images to 100%

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -136,7 +136,7 @@ h3 {
   }
 
   img {
-    max-width: 35em;
+    max-width: 100%;
   }
 
   th, td {


### PR DESCRIPTION
I was just checking out the new [blog post](https://brew.sh/2024/07/26/homebrew-summer-2024-hackathon/) on my phone and it looked a bit off. Turns out that the images have a set width that exceeds the viewport on smaller devices, not quite sure why but maybe this was a good "magic variable" at some point which worked well on larger viewports?

I changed the `width` property to `100%` to make sure that the image doesn't overflow it's container and then will never overflow beyond the text in the wrapped container.

| before | after |
|--|--|
| ![before](https://github.com/user-attachments/assets/65cce0df-22e7-476b-9134-fec04c6d834c) | ![after](https://github.com/user-attachments/assets/6cf9fe1b-b374-42af-a351-c54bbcf1ce7c) |

(Screenshots on emulated iPhone 14 Pro Max in the Chrome DevTools)