### PR TITLE
Homebrew 4.4.0

### DIFF
--- a/_posts/2024-10-01-homebrew-4.4.0.md
+++ b/_posts/2024-10-01-homebrew-4.4.0.md
@@ -15,7 +15,7 @@ Major changes and deprecations since 4.3.0:
 - [External commands in the old, non-AbstractCommand style are deprecated and should be migrated to AbstractCommand.](https://github.com/Homebrew/brew/pull/18008)
 - [Disabled packages output the date when they will be disabled.](https://github.com/Homebrew/brew/pull/17721)
 - [`url do` blocks are deprecated for casks.](https://github.com/Homebrew/brew/pull/18407)
-- [A Ubuntu 24.04 Docker image was added.](https://github.com/Homebrew/brew/pull/17293)
+- [An Ubuntu 24.04 Docker image was added.](https://github.com/Homebrew/brew/pull/17293)
 - [The Ubuntu 18.04 Homebrew Docker image is deprecated.](https://github.com/Homebrew/brew/pull/18387)
 - [`brew tab` is a new command for editing tab information.](https://github.com/Homebrew/brew/pull/17449)
 - [Setting Homebrew's boolean environment variables to falsey values is deprecated.](https://github.com/Homebrew/brew/pull/18408)
@@ -36,8 +36,8 @@ Other changes since 4.3.0 I'd like to highlight are the following:
 - [`brew list` has new `--poured-from-bottle` and `--built-from-source` flags.](https://github.com/Homebrew/brew/pull/18133)
 - [`brew shellenv` will set `XDG_DATA_DIRS` on Linux.](https://github.com/Homebrew/brew/pull/18326)
 - [`brew typecheck` supports using Sorbet for typechecking in taps.](https://github.com/Homebrew/brew/pull/18027)
-- [`HOMEBREW_NO_BUILD_ERROR_ISSUES` is a new environment variable prevents Homebrew from searching for relevant GitHub issues on a build error.](https://github.com/Homebrew/brew/pull/18313)
-- [`brew search` allows seraching with `@` and `+` characters.](https://github.com/Homebrew/brew/pull/18345)
+- [`HOMEBREW_NO_BUILD_ERROR_ISSUES` is a new environment variable that prevents Homebrew from searching for relevant GitHub issues on a build error.](https://github.com/Homebrew/brew/pull/18313)
+- [`brew search` allows searching with `@` and `+` characters.](https://github.com/Homebrew/brew/pull/18345)
 - [A `homebrew/brew:master` Docker image was added.](https://github.com/Homebrew/brew/pull/18396)
 
 Finally:

--- a/_posts/2024-10-01-homebrew-4.4.0.md
+++ b/_posts/2024-10-01-homebrew-4.4.0.md
@@ -1,0 +1,51 @@
+---
+title: 4.4.0
+author: MikeMcQuaid
+redirect_from: /blog/4.4.0/
+---
+
+Today, I'd like to announce Homebrew 4.4.0.
+The most significant changes since 4.3.0 are official macOS Sequoia (15) support, `INSTALL_RECEIPT.json` files for casks, macOS Monterey (12) deprecation and various other deprecations.
+
+Major changes and deprecations since 4.3.0:
+
+- [macOS Sequoia (15) is officially supported by Homebrew.](https://github.com/Homebrew/brew/pull/18296)
+- [Newly installed casks have install receipts (`INSTALL_RECEIPT.json` files).](https://github.com/Homebrew/brew/pull/17554)
+- [macOS Monterey (12) is no longer supported by Homebrew and no longer a CI target for Homebrew.](https://github.com/Homebrew/brew/pull/18314)
+- [External commands in the old, non-AbstractCommand style are deprecated and should be migrated to AbstractCommand.](https://github.com/Homebrew/brew/pull/18008)
+- [Disabled packages output the date when they will be disabled.](https://github.com/Homebrew/brew/pull/17721)
+- [`url do` blocks are deprecated for casks.](https://github.com/Homebrew/brew/pull/18407)
+- [A Ubuntu 24.04 Docker image was added.](https://github.com/Homebrew/brew/pull/17293)
+- [The Ubuntu 18.04 Homebrew Docker image is deprecated.](https://github.com/Homebrew/brew/pull/18387)
+- [`brew tab` is a new command for editing tab information.](https://github.com/Homebrew/brew/pull/17449)
+- [Setting Homebrew's boolean environment variables to falsey values is deprecated.](https://github.com/Homebrew/brew/pull/18408)
+- [Homebrew no longer supports building with GCC 4.9, 5 and 6.](https://github.com/Homebrew/brew/pull/18127)
+- [The usual cycle of deprecations, disables and code removals.](https://github.com/Homebrew/brew/pull/18388)
+
+Other changes since 4.3.0 I'd like to highlight are the following:
+
+- [Homebrew uses Ruby 3.3.5.](https://github.com/Homebrew/brew/pull/18439)
+- [`brew upgrade --cask --quiet` is quieter.](https://github.com/Homebrew/brew/pull/17761)
+- [`brew outdated` assumes the `--greedy` flag was passed when `HOMEBREW_UPGRADE_GREEDY` is set.](https://github.com/Homebrew/brew/pull/17668)
+- [`brew install --cask --adopt` only cares if the cask doesn't auto-update.](https://github.com/Homebrew/brew/pull/18420)
+- [`brew search --desc` and `brew desc --search` use the JSON API's data for description searches.](https://github.com/Homebrew/brew/pull/17582)
+- [`brew autoremove` does not remove formulae that were built from source.](https://github.com/Homebrew/brew/pull/17508)
+- [Homebrew will rewrite `node` shebangs on installation (mirroring `python` and `perl`).](https://github.com/Homebrew/brew/pull/17773)
+- [`brew install` will prioritise homebrew-cask casks over non-Homebrew organisation formulae.](https://github.com/Homebrew/brew/pull/17681)
+- [`brew info` will show size information for bottles.](https://github.com/Homebrew/brew/pull/18172)
+- [`brew list` has new `--poured-from-bottle` and `--built-from-source` flags.](https://github.com/Homebrew/brew/pull/18133)
+- [`brew shellenv` will set `XDG_DATA_DIRS` on Linux.](https://github.com/Homebrew/brew/pull/18326)
+- [`brew typecheck` supports using Sorbet for typechecking in taps.](https://github.com/Homebrew/brew/pull/18027)
+- [`HOMEBREW_NO_BUILD_ERROR_ISSUES` is a new environment variable prevents Homebrew from searching for relevant GitHub issues on a build error.](https://github.com/Homebrew/brew/pull/18313)
+- [`brew search` allows seraching with `@` and `+` characters.](https://github.com/Homebrew/brew/pull/18345)
+- [A `homebrew/brew:master` Docker image was added.](https://github.com/Homebrew/brew/pull/18396)
+
+Finally:
+
+- Homebrew's [501c3 OpenCollective](https://opencollective.com/brew) is empty.
+  We are only using our [501c6 OpenCollective](https://opencollective.com/homebrew).
+- In case you missed it, Homebrew had a [2023 security audit](https://brew.sh/2024/07/30/homebrew-security-audit/) that was released in July.
+- Homebrew had a [Summer 2024 Hackathon](https://brew.sh/2024/07/26/homebrew-summer-2024-hackathon/) in July which focused on implementing the results of the security audit and improving performance of many parts of Homebrew.
+- [Homebrew accepts donations through GitHub Sponsors](https://github.com/sponsors/Homebrew) and [still accepts donations through Patreon](https://www.patreon.com/homebrew). If you can afford it, please consider donating. If you'd rather not use GitHub Sponsors or Patreon (our preferred donation methods), [check out the other ways to donate in our README](https://github.com/Homebrew/brew/#donations).
+
+Thanks to all our hard-working maintainers, contributors, sponsors and supporters for getting us this far.


### PR DESCRIPTION
Release notes blog post for Homebrew 4.4.0.

Homebrew/brew release: https://github.com/Homebrew/brew/releases/tag/untagged-e83f81f6dacd7e409e88