### PR TITLE
Add pagination to blog archives

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# https://editorconfig.org/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[**.{md,html}]
+x-soft-wrap-text = true

--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,7 @@ exclude:
 
 plugins:
   - jekyll-feed
+  - jekyll-paginate
   - jekyll-redirect-from
   - jekyll-remote-theme
   - jekyll-seo-tag
@@ -20,6 +21,8 @@ feed:
   path: atom.xml
 
 permalink: :title
+paginate: 15
+paginate_path: "/blog/page-:num/"
 
 defaults:
   - scope:

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -382,6 +382,18 @@ button::-moz-focus-inner {
   margin: 1em 0;
 }
 
+.pagination {
+  text-align: center;
+
+  a, span {
+    display: inline-block;
+    margin: 0 0.4em;
+  }
+  .page_number {
+    font-style: italic;
+  }
+}
+
 :root {
   --docsearch-primary-color: #{$color_marigold_approx} !important;
   --docsearch-modal-background: #{$color_rangitoto_approx} !important;

--- a/blog/index.html
+++ b/blog/index.html
@@ -4,7 +4,7 @@ layout: base
 ---
 
 <ul class="posts">
-  {% for post in site.posts -%}
+  {% for post in paginator.posts -%}
     <li>
       <a href="{{ post.url }}" title="{{ post.title }}">
         <h2>{{ post.title }}</h2>
@@ -16,5 +16,31 @@ layout: base
     </li>
   {% endfor -%}
 </ul>
+
+<div class="pagination">
+  {% if paginator.page != 1 %}
+    <a href="/blog/" class="first">&laquo;&nbsp;First</a>
+  {% else %}
+    <span class="first">&laquo;&nbsp;First</span>
+  {% endif %}
+  {% if paginator.previous_page %}
+    <a href="{{ paginator.previous_page_path }}" class="previous">&lsaquo;&nbsp;Previous</a>
+  {% else %}
+    <span class="previous">&lsaquo;&nbsp;Previous</span>
+  {% endif %}
+  <span class="page_number ">
+    Page: {{ paginator.page }} of {{ paginator.total_pages }}
+  </span>
+  {% if paginator.next_page %}
+    <a href="{{ paginator.next_page_path }}" class="next">Next&nbsp;&rsaquo;</a>
+  {% else %}
+    <span class="next">Next&nbsp;&rsaquo;</span>
+  {% endif %}
+  {% if paginator.page != paginator.total_pages %}
+    <a href="/blog/page-{{ paginator.total_pages }}/" class="last">Last&nbsp;&raquo;</a>
+  {% else %}
+    <span class="last">Last&nbsp;&raquo;</span>
+  {% endif %}
+</div>
 
 {%- include newsletter.html -%}


### PR DESCRIPTION
Make use of jekyll-paginate, which is [available for GitHub Pages](https://pages.github.com/versions/). 15 posts per page gives 3 pages currently. 

Also added an `.editorconfig` file. 