### PR TITLE
Accessibility improvements: contain page content in landmarks, remove repeated author avatar alt tag

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -146,7 +146,11 @@ algolia:
       {% assign forkme_url = "https://github.com/Homebrew/brew" -%}
     {% endif -%}
 
-    <a href="{{ forkme_url }}"><img id="forkme" src="{{ "/assets/img/forkme_right_gray_6d6d6d.svg" | relative_url }}" alt="Fork me on GitHub"></a>
+    <aside>
+      <a href="{{ forkme_url }}">
+        <img id="forkme" src="{{ "/assets/img/forkme_right_gray_6d6d6d.svg" | relative_url }}" alt="Fork me on GitHub">
+      </a>
+    </aside>
     <script>
       function loadLanguage(lang) {
         if (lang === {{ page.lang | jsonify }}) {

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -119,14 +119,16 @@ algolia:
         {% endif -%}
         </header>
 
-      {% comment -%}
-        This is primarily intended to remove the trailing slash from the
-        self-closing `img` tags that result from rendered Markdown text.
-      {% endcomment -%}
-      {% capture rendered_content -%}
-        {{ content }}
-      {% endcapture -%}
-      {{ rendered_content | replace: " />", ">" | replace: "/>", ">" -}}
+      <main> 
+        {% comment -%}
+          This is primarily intended to remove the trailing slash from the
+          self-closing `img` tags that result from rendered Markdown text.
+        {% endcomment -%}
+        {% capture rendered_content -%}
+          {{ content }}
+        {% endcapture -%}
+        {{ rendered_content | replace: " />", ">" | replace: "/>", ">" -}}
+      </main>
     </div>
 
     {% if site.forkme_nwo -%}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -4,7 +4,7 @@ layout: base
 <article id="post">
   <h2>{{ page.title }}</h2>
   <h3>{{ page.date | date_to_long_string }}</h3>
-  <h3 class="author"><a href="https://github.com/{{ page.author }}"><img class="avatar" src="https://avatars2.githubusercontent.com/{{ page.author }}?v=3&amp;s=80" alt="{{ page.author }}" width="40" height="40">{{ page.author }}</a></h3>
+  <h3 class="author"><a href="https://github.com/{{ page.author }}"><img class="avatar" src="https://avatars2.githubusercontent.com/{{ page.author }}?v=3&amp;s=80" alt="" width="40" height="40">{{ page.author }}</a></h3>
   <div class="postcontent singlepostcontent">
     {{ content }}
 


### PR DESCRIPTION
Addresses 3 accessibility issues identified with [axe DevTools](https://www.deque.com/axe/devtools/):
- Document should have one main landmark (19508c75854692924dc368af291ad25d3bbad7e5)
- All page content should be contained by landmarks (65c5be3de932282bf1ec4dd6c7b74dad774eabe8)
- Alternative text of images should not be repeated as text (83797a5abc5e357f994cec1daed95fb2b03f4114)