### PR TITLE
homebrew-4.6.0: add cask signing reference.

### DIFF
--- a/_posts/2025-08-05-homebrew-4.6.0.md
+++ b/_posts/2025-08-05-homebrew-4.6.0.md
@@ -22,6 +22,8 @@ Other changes since 4.5.0 I'd like to highlight are the following:
 - All repositories in the Homebrew organisation, including e.g. [Homebrew/brew](https://github.com/Homebrew/brew/pull/20164),
   [Homebrew/homebrew-cask](https://github.com/Homebrew/brew/pull/20172) and
   [Homebrew/homebrew-core](https://github.com/Homebrew/brew/pull/20171), now use `main` as their default branch.
+- [All casks submitted in Homebrew/homebrew-cask must be signed](https://github.com/Homebrew/brew/pull/20286).
+  We have not yet completed the process of disabling/removing those that aren't but this will happen at some point in the future.
 - [Homebrew prohibits non-ASCII characters in URLs.](https://github.com/Homebrew/brew/pull/19977)
 - [Homebrew now allows users in Tier 2/3 to file some types of issues.](https://github.com/Homebrew/brew/pull/20185)
 - [Homebrew's `.pkg` and official/shell installers will now add Homebrew to the default `PATH` if possible.](https://github.com/Homebrew/brew/pull/20159)


### PR DESCRIPTION
This was mistakenly not added to the original post.