### PR TITLE
Increase font-size of code & credits

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -282,7 +282,7 @@ pre {
 
   code {
     font-family: "ui-monospace", "SF Mono", "Monaco", "Menlo", "Consolas", monospace;
-    font-size: 11px;
+    font-size: .8em;
     line-height: 1.6;
   }
 }
@@ -510,7 +510,7 @@ button::-moz-focus-inner {
 
   .credits {
     border-bottom: none;
-    font-size: 70%;
+    font-size: .8em;
     text-align: center;
     padding-top: 1.8em;
 


### PR DESCRIPTION
Increases the font-size of `pre code` and `#information .credits` to the Lighthouse minimum recommended font size of 12px, improving text legibility and hopefully the page Lighthouse score ([document doesn't use legible font sizes](https://developer.chrome.com/docs/lighthouse/seo/font-size/)).