### PR TITLE
Add no-stack table class for narrow viewports

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1086,6 +1086,7 @@ span .amp {
     }
 
     .number-data {
+      width: 1%;
       text-align: right;
     }
   }

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1071,6 +1071,25 @@ span .amp {
     }
   }
 
+  table.no-stack {
+    width: 100%;
+
+    tr {
+      display: table-row;
+      padding: 0;
+    }
+
+    th, td {
+      display: table-cell;
+      text-align: left;
+      max-width: none;
+    }
+
+    .number-data {
+      text-align: right;
+    }
+  }
+
   #forkme {
     width: 100px;
     height: 100px;


### PR DESCRIPTION
The mobile media query stacks every table cell vertically (`display: block`), which makes the bottle and analytics tables on formulae.brew.sh very tall on small screens. This adds a `no-stack` class that opts a table out of that behaviour and keeps it in row/column layout with left-aligned cells and right-aligned numbers.

Used by Homebrew/formulae.brew.sh#2254 (see screenshots there).