### PR TITLE
styles: add `bottles` CSS id

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -352,6 +352,14 @@ div .highlight {
   }
 }
 
+#bottles {
+  border-collapse: collapse;
+
+  tbody:not(:first-child) {
+    border-top: 10px solid rgba(0, 0, 0, 0.6);
+  }
+}
+
 pre {
   margin: 0 0 1em 0;
   background: $black_30;


### PR DESCRIPTION
CSS id for `Bottle` (formulae) / `Supported platforms` (casks) table that adds a separator between `<tbody>` tags

See https://github.com/Homebrew/formulae.brew.sh/pull/2282#issuecomment-5476123371